### PR TITLE
Fix AppQuitConfirmationUiManager double negation in Spanish

### DIFF
--- a/main/fdm_es.po
+++ b/main/fdm_es.po
@@ -317,7 +317,7 @@ msgstr "Borrando archivos."
 
 msgctxt "AppQuitConfirmationUiManager|"
 msgid "There are operations with no resume capability in progress"
-msgstr "No hay operaciones sin soporte de reanudar en progreso"
+msgstr "Hay operaciones sin soporte de reanudar en progreso"
 
 msgctxt "AuthenticationDialog|"
 msgid "Authentication required"


### PR DESCRIPTION
Currently the translation says "There are no operations with no resume capability in progress"