### PR TITLE
Added Finnish translation.

### DIFF
--- a/main/fdm_fi.po
+++ b/main/fdm_fi.po
@@ -1,0 +1,4929 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Syklis\n"
+"Language-Team: Syklis\n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Language: fi\n"
+"X-Source-Language: en\n"
+"X-Qt-Contexts: true\n"
+"X-Generator: Poedit 3.3.2\n"
+
+msgctxt "AboutDialog|"
+msgid "About"
+msgstr "Tietoja"
+
+msgctxt "AboutDialog|"
+msgid "Version: %1 (%2)"
+msgstr "Versio: %1 (%2)"
+
+msgctxt "AboutDialog|"
+msgid "Build date: %1"
+msgstr "Päivämäärä: %1"
+
+msgctxt "AboutDialog|"
+msgid "© %1, %2-%3"
+msgstr "© %1, %2-%3"
+
+msgctxt "AboutDialog|"
+msgid "remote control"
+msgstr "etähallinta"
+
+msgctxt "AboutDialog|"
+msgid "version %1"
+msgstr "versio %1"
+
+msgctxt "AboutDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "AboutDialog|"
+msgid "Version %1 (%2)"
+msgstr "Versio %1 (%2)"
+
+msgctxt "AddDateToFileName|"
+msgid "Add dates to files names"
+msgstr "Lisää päivämäärä tiedostonimiin"
+
+msgctxt "AddMirrorDialog|"
+msgid "Add mirror"
+msgstr "Lisää toisiopalvelin"
+
+msgctxt "AddMirrorDialog|"
+msgid "Enter mirror URL"
+msgstr "Toisiopalvelimen URL"
+
+msgctxt "AddMirrorDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "AddMirrorDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "AddMirrorPage|"
+msgid "Add mirror"
+msgstr "Lisää toisiopalvelin"
+
+msgctxt "AddMirrorPage|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "AddMirrorPage|"
+msgid "Enter mirror URL"
+msgstr "Toisiopalvelimen URL"
+
+msgctxt "AddTDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "AddTDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "AddTPage|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "AddTag|"
+msgid "Add tag"
+msgstr "Lisää tägi"
+
+msgctxt "AdvancedSettings|"
+msgid "Advanced"
+msgstr "Lisäasetukset"
+
+msgctxt "AdvancedSettings|"
+msgid "Notifications"
+msgstr "Ilmoitukset"
+
+msgctxt "AdvancedSettings|"
+msgid "Notify me of added downloads via Notification Center"
+msgstr "Ilmoita uusista latauksista Ilmoituskeskuksessa"
+
+msgctxt "AdvancedSettings|"
+msgid "Notify me of completed downloads via Notification Center"
+msgstr "Ilmoita valmistuneista latauksista Ilmoituskeskuksessa"
+
+msgctxt "AdvancedSettings|"
+msgid "Notify me of failed downloads via Notification Center"
+msgstr "Ilmoita epäonnistuneista latauksista Ilmoituskeskuksessa"
+
+msgctxt "AdvancedSettings|"
+msgid "Notify me of downloads only when %1 window is inactive"
+msgstr "Ilmoita vain kun %1-ikkuna ei ole aktiivinen"
+
+msgctxt "AdvancedSettings|"
+msgid "Customize sounds"
+msgstr "Muokkaa ääniä"
+
+msgctxt "AdvancedSettings|"
+msgid "Power management"
+msgstr "Virranhallinta"
+
+msgctxt "AdvancedSettings|"
+msgid "Don't put your computer to sleep if there is an active download"
+msgstr ""
+"Älä aseta tietokonetta lepotilaan aktiivisten latausten ollessa käynnissä"
+
+msgctxt "AdvancedSettings|"
+msgid "Enable sleep mode while running finished downloads"
+msgstr "Lepotila valmistuneiden latausten ollessa käynnissä"
+
+msgctxt "AdvancedSettings|"
+msgid "Options"
+msgstr "Valinnat"
+
+msgctxt "AdvancedSettings|"
+msgid "Launch at startup (minimized)"
+msgstr "Käynnistä tietokoneen käynnistyessä (pienennettynä)"
+
+msgctxt "AdvancedSettings|"
+msgid "Show special offers"
+msgstr "Näytä erikoistarjouksia"
+
+msgctxt "AdvancedSettings|"
+msgid "Interface"
+msgstr "Käyttöliittymä"
+
+msgctxt "AdvancedSettings|"
+msgid "Open/hide the bottom panel by clicking on the download"
+msgstr "Avaa/sulje alapaneeli klikkaamalla latausta"
+
+msgctxt "AdvancedSettings|"
+msgid "Indicate active download and upload using tray icon"
+msgstr "Näytä aktiivinen lataus ja lähetys ilmaisinpalkin kuvakkeella"
+
+msgctxt "AdvancedSettings|"
+msgid "Show built-in tags:"
+msgstr "Näytä valmistägit:"
+
+msgctxt "AdvancedSettings|"
+msgid "Automation"
+msgstr "Automaatio"
+
+msgctxt "AdvancedSettings|"
+msgid "Launch external application on download completion"
+msgstr "Käynnistä ulkoinen ohjelma latauksen valmistuttua"
+
+msgctxt "AdvancedSettings|"
+msgid "Path:"
+msgstr "Polku:"
+
+msgctxt "AdvancedSettings|"
+msgid "Please enter application's path"
+msgstr "Ohjelman polku"
+
+msgctxt "AdvancedSettings|"
+msgid "Arguments:"
+msgstr "Argumentit:"
+
+msgctxt "AdvancedSettings|"
+msgid "Arguments must contain %path% variable"
+msgstr "Argumenttien täytyy sisältää %path% -muuttuja"
+
+msgctxt "AdvancedSettings|"
+msgid "Go back to default settings"
+msgstr "Palauta oletusasetukset"
+
+msgctxt "AdvancedSettings|"
+msgid "Reset"
+msgstr "Nollaa"
+
+msgctxt "AdvancedSettings|"
+msgid "Default settings"
+msgstr "Oletusasetukset"
+
+msgctxt "AdvancedSettings|"
+msgid "Restore default settings?"
+msgstr "Palauta oletusasetukset?"
+
+msgctxt "AdvancedSettings|"
+msgid "Backup the list of downloads every"
+msgstr "Latauslistan varmuuskopioinnin aikaväli"
+
+msgctxt "AdvancedSettings|"
+msgid "File exists reaction"
+msgstr "Kun tiedosto on jo olemassa"
+
+msgctxt "AdvancedSettings|"
+msgid "Rename"
+msgstr "Nimeä uudelleen"
+
+msgctxt "AdvancedSettings|"
+msgid "Overwrite"
+msgstr "Päällekirjoita"
+
+msgctxt "AdvancedSettings|"
+msgid "Use sounds"
+msgstr "Käytä ääniä"
+
+msgctxt "AdvancedSettings|"
+msgid ""
+"Do not allow downloads to perform post finished tasks when running on battery"
+msgstr "Älä salli latausten suorittaa tehtäviä akkuvirralla valmistuttuaan"
+
+msgctxt "AdvancedSettings|"
+msgid "Do not allow downloads if battery level drops below"
+msgstr "Älä salli latauksia, jos akun varaus laskee alle"
+
+msgctxt "AdvancedSettings|"
+msgid "Enable user defined order of downloads"
+msgstr "Ota käyttöön käyttäjän määrittelemä latausjärjestys"
+
+msgctxt "AdvancedSettings|"
+msgid "Show \"Save As...\" button"
+msgstr "Näytä \"Tallenna nimellä...\" painike"
+
+msgctxt "AdvancedSettings|"
+msgid "Enable standalone create new downloads windows"
+msgstr "Ota käyttöön itsenäiset \"uusi lataus\" -ikkunat"
+
+msgctxt "AdvancedSettings|"
+msgid "Overall zoom"
+msgstr "Käyttöliittymän skaalaus"
+
+msgctxt "AdvancedSettings|"
+msgid "Fonts zoom"
+msgstr "Fontin skaalaus"
+
+msgctxt "AdvancedSettings|"
+msgid "Delete button action"
+msgstr "Poista-painikkeen toiminto"
+
+msgctxt "AdvancedSettings|"
+msgid "Remove only from download list"
+msgstr "Poista vain latauslistasta"
+
+msgctxt "AdvancedSettings|"
+msgid "Delete files"
+msgstr "Poista tiedostot"
+
+msgctxt "AdvancedSettings|"
+msgid "Always ask"
+msgstr "Kysy erikseen"
+
+msgctxt "AdvancedSettings|"
+msgid "Advanced settings"
+msgstr "Lisäasetukset"
+
+msgctxt "AdvancedSettings|"
+msgid "Choose theme"
+msgstr "Valitse teema"
+
+msgctxt "AdvancedSettings|"
+msgid "A light theme will be used, if the system theme is unknown."
+msgstr "Vaaleaa teemaa käytetään, jos järjestelmäteema ei ole tiedossa."
+
+msgctxt "AntivirusComboBox|"
+msgid "Configure manually..."
+msgstr "Aseta manuaalisesti..."
+
+msgctxt "AntivirusSettings|"
+msgid "Antivirus"
+msgstr "Virustorjunta"
+
+msgctxt "AntivirusSettings|"
+msgid "Select antivirus:"
+msgstr "Valitse virustorjunta:"
+
+msgctxt "AntivirusSettings|"
+msgid "Is your antivirus not listed?"
+msgstr "Eikö virustorjuntaa näy?"
+
+msgctxt "AntivirusSettings|"
+msgid "Path:"
+msgstr "Polku:"
+
+msgctxt "AntivirusSettings|"
+msgid "Please enter antivirus path"
+msgstr "Virustorjunnan polku"
+
+msgctxt "AntivirusSettings|"
+msgid "Arguments:"
+msgstr "Argumentit:"
+
+msgctxt "AntivirusSettings|"
+msgid "Arguments must contain %path% variable"
+msgstr "Argumenttien täytyy sisältää %path% -muuttuja"
+
+msgctxt "AntivirusSettings|"
+msgid "Automatically perform virus check when download is finished"
+msgstr "Suorita virustarkistus automaattisesti latauksen valmistuttua"
+
+msgctxt "AntivirusSettingsDialog|"
+msgid "Virus check"
+msgstr "Virustarkastus"
+
+msgctxt "AntivirusSettingsDialog|"
+msgid "There is no antivirus specified in the settings."
+msgstr "Virustorjuntaa ei ole määritetty."
+
+msgctxt "AntivirusSettingsDialog|"
+msgid "Go to settings"
+msgstr "Avaa asetukset"
+
+msgctxt "AntivirusSettingsDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "AppDenyShutdownIfHasOpsWithNoResumeSupportSwitch|"
+msgid "Downloads with no resume support (%1)."
+msgstr "Lataukset eivät tue jatkamista (%1)."
+
+msgctxt "AppDenyShutdownIfHasOpsWithNoResumeSupportSwitch|"
+msgid "Moving files (%1)."
+msgstr "Siirretään tiedostoja (%1)."
+
+msgctxt "AppDenyShutdownIfHasOpsWithNoResumeSupportSwitch|"
+msgid "Converting files to mp3 (%1)."
+msgstr "Käännetään tiedostoja mp3-muotoon (%1)."
+
+msgctxt "AppDenyShutdownIfHasOpsWithNoResumeSupportSwitch|"
+msgid "Converting files to mp4 (%1)."
+msgstr "Käännetään tiedostoja mp4-muotoon (%1)."
+
+msgctxt "AppDenyShutdownIfHasOpsWithNoResumeSupportSwitch|"
+msgid "Renaming files (%1)."
+msgstr "Uudelleennimetään tiedostoja (%1)."
+
+msgctxt "AppDenyShutdownIfHasOpsWithNoResumeSupportSwitch|"
+msgid "Merging media streams (%1)."
+msgstr "Yhdistetään mediastriimejä (%1)."
+
+msgctxt "AppDenyShutdownIfHasOpsWithNoResumeSupportSwitch|"
+msgid "Deleting files."
+msgstr "Poistetaan tiedostoja."
+
+msgctxt "AppQuitConfirmationUiManager|"
+msgid "There are operations with no resume capability in progress"
+msgstr "Jatkamista tukemattomia toimintoja on edelleen käynnissä"
+
+msgctxt "AppRcClientLoadManager|"
+msgid "Connecting to remote %1 (%2)..."
+msgstr "Yhdistetään etäyhteyteen %1 (%2)…"
+
+msgctxt "AppRcClientLoadManager|"
+msgid "Getting data from remote %1 (%2)..."
+msgstr "Luetaan tietoja etäyhteydeltä %1 (%2)…"
+
+msgctxt "AppRcClientLoadManager|"
+msgid "Failed."
+msgstr "Epäonnistui."
+
+msgctxt "AuthDialog|"
+msgid "Authentication required"
+msgstr "Todentaminen vaaditaan"
+
+msgctxt "AuthDialog|"
+msgid "%1 requires authentication"
+msgstr "%1 vaatii todennusta"
+
+msgctxt "AuthDialog|"
+msgid "The site says: \"%1\"."
+msgstr "Palvelin sanoo: \"%1\"."
+
+msgctxt "AuthDialog|"
+msgid "Username:"
+msgstr "Käyttäjänimi:"
+
+msgctxt "AuthDialog|"
+msgid "Password:"
+msgstr "Salasana:"
+
+msgctxt "AuthDialog|"
+msgid "remember"
+msgstr "muista"
+
+msgctxt "AuthDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "AuthDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "AuthenticationDialog|"
+msgid "Authentication required"
+msgstr "Todentaminen vaaditaan"
+
+msgctxt "AuthenticationDialog|"
+msgid "The site says: \"%1\"."
+msgstr "Palvelin sanoo: \"%1\"."
+
+msgctxt "AuthenticationDialog|"
+msgid "Username:"
+msgstr "Käyttäjätunnus:"
+
+msgctxt "AuthenticationDialog|"
+msgid "Password:"
+msgstr "Salasana:"
+
+msgctxt "AuthenticationDialog|"
+msgid "remember"
+msgstr "muista"
+
+msgctxt "AuthenticationDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "AuthenticationDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "AuthenticationPage|"
+msgid "Authentication required"
+msgstr "Todentaminen vaaditaan"
+
+msgctxt "AuthenticationPage|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "AuthenticationPage|"
+msgid "The site says: \"%1\"."
+msgstr "Palvelin sanoo: \"%1\"."
+
+msgctxt "AuthenticationPage|"
+msgid "Username"
+msgstr "Käyttäjänimi"
+
+msgctxt "AuthenticationPage|"
+msgid "Password"
+msgstr "Salasana"
+
+msgctxt "AuthenticationPage|"
+msgid "Remember"
+msgstr "Muista"
+
+msgctxt "BackupComboBox|"
+msgid "5 minutes"
+msgstr "5 minuuttia"
+
+msgctxt "BackupComboBox|"
+msgid "15 minutes"
+msgstr "15 minuuttia"
+
+msgctxt "BackupComboBox|"
+msgid "1 hour"
+msgstr "1 tunti"
+
+msgctxt "BackupComboBox|"
+msgid "3 hours"
+msgstr "3 tuntia"
+
+msgctxt "BackupComboBox|"
+msgid "1 day"
+msgstr "1 päivä"
+
+msgctxt "BackupSlider|"
+msgid "5 minutes"
+msgstr "5 minuuttia"
+
+msgctxt "BackupSlider|"
+msgid "15 minutes"
+msgstr "15 minuuttia"
+
+msgctxt "BackupSlider|"
+msgid "1 hour"
+msgstr "1 tunti"
+
+msgctxt "BackupSlider|"
+msgid "3 hours"
+msgstr "3 tuntia"
+
+msgctxt "BackupSlider|"
+msgid "1 day"
+msgstr "1 päivä"
+
+msgctxt "BaseStringListArea|"
+msgid "Please enter one item per line"
+msgstr "Vain yksi per rivi"
+
+msgctxt "BaseTextArea|"
+msgid "Cut"
+msgstr "Leikkaa"
+
+msgctxt "BaseTextArea|"
+msgid "Copy"
+msgstr "Kopioi"
+
+msgctxt "BaseTextArea|"
+msgid "Paste"
+msgstr "Liitä"
+
+msgctxt "BaseTextField|"
+msgid "Cut"
+msgstr "Leikkaa"
+
+msgctxt "BaseTextField|"
+msgid "Copy"
+msgstr "Kopioi"
+
+msgctxt "BaseTextField|"
+msgid "Paste"
+msgstr "Liitä"
+
+msgctxt "BatchVideoQuality|"
+msgid "Max. video quality:"
+msgstr "Korkein videon laatu:"
+
+msgctxt "BitrateComboBox|"
+msgid "kbps"
+msgstr "kbps"
+
+# Need more context to use the right word.
+msgctxt "BitrateComboBox|"
+msgid "From %1 %2 to %3 %4"
+msgstr ""
+
+msgctxt "BitrateComboBox|"
+msgid "CD quality"
+msgstr "CD-laatu"
+
+msgctxt "BitrateComboBox|"
+msgid "High quality"
+msgstr "Korkea laatu"
+
+msgctxt "BitrateComboBox|"
+msgid "Medium quality"
+msgstr "Keskilaatu"
+
+msgctxt "BitrateComboBox|"
+msgid "Radio quality"
+msgstr "Radiolaatu"
+
+msgctxt "BitrateComboBox|"
+msgid "Low quality"
+msgstr "Matala laatu"
+
+msgctxt "BitrateComboBox|"
+msgid "Speech"
+msgstr "Puhe"
+
+msgctxt "BitrateComboBox|"
+msgid "Lowest quality, smallest file size"
+msgstr "Matalin laatu, pienin tiedostokoko"
+
+msgctxt "BottomPanelTools|"
+msgid "General"
+msgstr "Yleinen"
+
+msgctxt "BottomPanelTools|"
+msgid "Progress"
+msgstr "Edistys"
+
+msgctxt "BottomPanelTools|"
+msgid "Files"
+msgstr "Tiedostot"
+
+msgctxt "BottomPanelTools|"
+msgid "Connections"
+msgstr "Yhteydet"
+
+msgctxt "Browser|"
+msgid "Enter URL"
+msgstr "URL"
+
+msgctxt "Browser|"
+msgid "Bookmark removed"
+msgstr "Kirjanmerkki poistettu"
+
+msgctxt "Browser|"
+msgid "Bookmark added"
+msgstr "Kirjanmerkki lisätty"
+
+msgctxt "Browser|"
+msgid "Bookmarks"
+msgstr "Kirjanmerkit"
+
+msgctxt "Browser|"
+msgid "There are no bookmarks at the moment"
+msgstr "Kirjanmerkkejä ei ole"
+
+msgctxt "Browser|"
+msgid "Are you sure you want to remove this bookmark?"
+msgstr "Haluatko varmasti poistaa tämän kirjanmerkin?"
+
+msgctxt "Browser|"
+msgid "YES"
+msgstr "KYLLÄ"
+
+msgctxt "Browser|"
+msgid "NO"
+msgstr "EI"
+
+msgctxt "Browser MainMenu|"
+msgid "Back to %1"
+msgstr "Takaisin: %1"
+
+msgctxt "Browser MainMenu|"
+msgid "Bookmarks"
+msgstr "Kirjanmerkit"
+
+msgctxt "Browser MainMenu|"
+msgid "Download media"
+msgstr "Lataa mediaa"
+
+msgctxt "Browser MainMenu|"
+msgid "Remove bookmark"
+msgstr "Poista kirjanmerkki"
+
+msgctxt "Browser MainMenu|"
+msgid "Add bookmark"
+msgstr "Lisää kirjanmerkki"
+
+msgctxt "BrowserButton|"
+msgid "Download %1 extension"
+msgstr "Lataa %1 laajennus"
+
+msgctxt "BrowserButton|"
+msgid "%1 is not installed"
+msgstr "%1 ei ole asennettuna"
+
+msgctxt "BrowserIntegrationSettings|"
+msgid "Browser Integration"
+msgstr "Selainintegraatio"
+
+msgctxt "BrowserIntegrationSettings|"
+msgid ""
+"Make sure you have %1 extension installed, otherwise, click one of the "
+"buttons below"
+msgstr "Varmista, että %1 laajennus on asennettuna"
+
+msgctxt "BrowserIntegrationSettings|"
+msgid "Other supported browsers"
+msgstr "Muut tuetut selaimet"
+
+msgctxt "BrowserIntegrationSettings|"
+msgid "Automatically catch downloads from browsers"
+msgstr "Lisää lataukset selaimista automaattisesti"
+
+msgctxt "BrowserIntegrationSettings|"
+msgid "Intercept downloads in your web browser"
+msgstr "Kaappaa lataukset selaimista"
+
+msgctxt "BrowserIntegrationSettings|"
+msgid "Start downloading without confirmation"
+msgstr "Aloita lataus ilman varmistusta"
+
+msgctxt "BrowserIntegrationSettings|"
+msgid "Skip domains"
+msgstr "Ohita osoitteet"
+
+msgctxt "BrowserIntegrationSettings|"
+msgid "Edit list"
+msgstr "Muokkaa listaa"
+
+msgctxt "BrowserIntegrationSettings|"
+msgid "Are you sure this is a valid domain?"
+msgstr "Onko tämä varmasti oikea osoite?"
+
+msgctxt "BrowserIntegrationSettings|"
+msgid "Skip files with extensions"
+msgstr "Ohita tiedostomuodot"
+
+msgctxt "BrowserIntegrationSettings|"
+msgid "Are you sure this is a valid file extension?"
+msgstr "Onko tämä varmasti oikea tiedostopääte?"
+
+msgctxt "BrowserIntegrationSettings|"
+msgid "Don't catch downloads smaller than"
+msgstr "Älä lisää latauksia, jotka ovat pienempiä kuin"
+
+msgctxt "BrowserIntegrationSettings|"
+msgid "Mbytes"
+msgstr "MB"
+
+msgctxt "BrowserIntegrationSettings|"
+msgid "Use browser if you cancel download via %1"
+msgstr "Käytä selainta, jos %1 peruu latauksen"
+
+msgctxt "BrowserIntroDialog|"
+msgid ""
+"You're about to open a built-in web browser.\n"
+"\n"
+"It helps you to add downloads into %1.\n"
+"\n"
+"Some of them (e.g. Google Drive downloads) can be added using this browser "
+"only, because they require additional information that your Android system's "
+"browser does not provide to %1 (or there is no universal way for all "
+"browsers to do this)."
+msgstr ""
+"Olet avaamassa sisäänrakennettua verkkoselainta.\n"
+"\n"
+"Voit lisätä sillä latauksia %1:iin.\n"
+"\n"
+"Jotkin lataukset (kuten lataukset kohteesta Google Drive) voidaan lisätä "
+"vain käyttämällä tätä selainta, sillä ne vaativat lisätietoja, joita "
+"Androidin järjestelmäselain ei tarjoa %1:lle (tai jos kaikille selaimille ei "
+"ole yhtä tapaa tehdä tätä)."
+
+msgctxt "BrowserIntroDialog|"
+msgid "Continue"
+msgstr "Jatka"
+
+msgctxt "BrowserListElement|"
+msgid "(browser is not installed)"
+msgstr "(selainta ei ole asennettu)"
+
+msgctxt "BtSettings|"
+msgid "General"
+msgstr "Yleinen"
+
+msgctxt "BtSettings|"
+msgid "Monitoring"
+msgstr "Seuranta"
+
+msgctxt "BtSettings|"
+msgid "Open"
+msgstr "Avaa"
+
+msgctxt "BtSettings|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "BtSettings|"
+msgid "Start downloading without confirmation"
+msgstr "Aloita lataus ilman varmistusta"
+
+msgctxt "BtSettings|"
+msgid "Privacy"
+msgstr "Yksityisyys"
+
+msgctxt "BtSettings|"
+msgid "Encryption:"
+msgstr "Salaus:"
+
+msgctxt "BtSettings|"
+msgid "No encryption allowed"
+msgstr "Älä salli salausta"
+
+msgctxt "BtSettings|"
+msgid "Prefer encryption"
+msgstr "Suosi salausta"
+
+msgctxt "BtSettings|"
+msgid "Require encryption"
+msgstr "Vaadi salausta"
+
+msgctxt "BtSettings|"
+msgid "Advanced"
+msgstr "Lisäasetukset"
+
+msgctxt "BtSettings|"
+msgid "Current port: %1"
+msgstr "Nykyinen portti: %1"
+
+msgctxt "BtSettings|"
+msgid "Custom port:"
+msgstr "Muu portti:"
+
+msgctxt "BtSettings|"
+msgid ""
+"The use of additional trackers can improve download speed in some cases. "
+"Lists of such trackers can be retrieved from different sources, e.g. from <a "
+"href='https://github.com/ngosang/trackerslist'>here</a>."
+msgstr ""
+"Lisäträkkereiden käyttäminen saattaa lisätä latausnopeutta joissain "
+"tapauksissa. Träkkerilistoja saa eri lähteistä, kuten <a href='https://"
+"github.com/ngosang/trackerslist'>täältä</a>."
+
+msgctxt "BtStrings|"
+msgid "Uploaded"
+msgstr "Lähetetty"
+
+msgctxt "BtStrings|"
+msgid "Ratio"
+msgstr "Suhde"
+
+msgctxt "BuildDownloadDialog|"
+msgid "Add download"
+msgstr "Lisää lataus"
+
+msgctxt "BuildDownloadDialog|"
+msgid "Report problem"
+msgstr "Ilmoita ongelmasta"
+
+msgctxt "BuildDownloadDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "BuildDownloadDialog|"
+msgid "Download"
+msgstr "Lataa"
+
+msgctxt "BuildDownloadDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "BuildDownloadPage|"
+msgid "Add download"
+msgstr "Lisää lataus"
+
+msgctxt "BuildDownloadPage|"
+msgid "Download"
+msgstr "Lataa"
+
+msgctxt "BuildDownloadPage|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "BuildDownloadPage|"
+msgid "Report problem"
+msgstr "Ilmoita ongelmasta"
+
+msgctxt "BuildDownloadPage|"
+msgid "Downloading from this site is not allowed"
+msgstr "Tästä osoitteesta lataaminen ei ole sallittua"
+
+msgctxt "BuildDownloadTools|"
+msgid "The proxy %1 requires a username and password."
+msgstr "Välityspalvelin %1 vaatii käyttäjätunnuksen ja salasanan."
+
+msgctxt "BuildDownloadTools|"
+msgid "%1 is requesting your username and password."
+msgstr "%1 pyytää käyttäjätunnusta ja salasanaa."
+
+msgctxt "BuildDownloadTools|"
+msgid "Querying info. Please wait..."
+msgstr "Pyydetään tietoja. Odota..."
+
+msgctxt "ButtonsBlock|"
+msgid "Please select download link"
+msgstr "Valitse latauslinkki"
+
+msgctxt "ButtonsBlock|"
+msgid "You can select no more than %1 links at a time"
+msgstr "Voit valita vain %1 linkkiä kerrallaan"
+
+msgctxt "ButtonsBlock|"
+msgid "No write access to the selected directory"
+msgstr "Ei kirjoitusoikeutta valittuun hakemistoon"
+
+msgctxt "ButtonsBlock|"
+msgid "Not enough disk space"
+msgstr "Ei riittävästi levytilaa"
+
+msgctxt "ButtonsBlock|"
+msgid "The path contains invalid characters"
+msgstr "Polku sisältää kiellettyjä merkkejä"
+
+msgctxt "ButtonsBlock|"
+msgid "The subfolder name contains invalid characters"
+msgstr "Alakansion nimi sisältää kiellettyjä merkkejä"
+
+msgctxt "ButtonsBlock|"
+msgid "The filename contains invalid characters"
+msgstr "Tiedostonimi sisältää kiellettyjä merkkejä"
+
+msgctxt "ButtonsBlock|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "ButtonsBlock|"
+msgid "Download"
+msgstr "Lataa"
+
+msgctxt "ChangeUrlDialog|"
+msgid "Change download URL"
+msgstr "Muuta latauksen URL-osoitetta"
+
+msgctxt "ChangeUrlDialog|"
+msgid "Enter new URL"
+msgstr "Uusi URL"
+
+msgctxt "ChangeUrlDialog|"
+msgid "File location: %1"
+msgstr "Tiedostosijainti: %1"
+
+msgctxt "ChangeUrlDialog|"
+msgid "Invalid URL"
+msgstr "Virheellinen URL"
+
+msgctxt "ChangeUrlDialog|"
+msgid "Start download"
+msgstr "Aloita lataus"
+
+msgctxt "ChangeUrlDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "ChangeUrlDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "ChangeUrlPage|"
+msgid "Change download URL"
+msgstr "Muuta latauksen URL-osoitetta"
+
+msgctxt "ChangeUrlPage|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "ChangeUrlPage|"
+msgid "Enter new URL"
+msgstr "Uusi URL"
+
+msgctxt "ChangeUrlPage|"
+msgid "File location: %1"
+msgstr "Tiedostosijainti: %1"
+
+msgctxt "ChangeUrlPage|"
+msgid "Start download"
+msgstr "Aloita lataus"
+
+msgctxt "ConfirmDeleteExtraneousFilesDialog|"
+msgid "Extraneous files are detected"
+msgstr "Ylimääräisiä tiedostoja havaittu"
+
+msgctxt "ConfirmDeleteExtraneousFilesDialog|"
+msgid ""
+"The following folder contains extraneous files. Do you still want to delete "
+"it?"
+msgstr ""
+"Kyseinen kansio sisältää ylimääräisiä tiedostoja. Haluatko silti poistaa sen?"
+
+msgctxt "ConfirmDeleteExtraneousFilesDialog|"
+msgid "Delete anyway"
+msgstr "Poista silti"
+
+msgctxt "ConfirmDeleteExtraneousFilesDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "ConnectToRemoteAppDialog|"
+msgid "Connect to remote %1"
+msgstr "Yhdistä etäyhteyteen %1"
+
+msgctxt "ConnectToRemoteAppDialog|"
+msgid "(beta)"
+msgstr "(beta)"
+
+msgctxt "ConnectToRemoteAppDialog|"
+msgid "Here you can connect to %1 running on another device."
+msgstr "Täällä voit yhdistää %1:iin, joka sijaitsee toisella laitteella."
+
+msgctxt "ConnectToRemoteAppDialog|"
+msgid "Automatically connect at startup"
+msgstr "Yhdistä automaattisesti käynnistyksessä"
+
+msgctxt "ConnectToRemoteAppDialog|"
+msgid "Please enter %1, or <a href='#'>scan QR code</a>"
+msgstr "Anna %1, tai <a href='#'>skannaa QR-koodi</a>"
+
+msgctxt "ConnectToRemoteAppDialog|"
+msgid ""
+"Both %1 and QR code are located inside of Preferences page of %2 you're "
+"going to connect to."
+msgstr "Sekä %1 että QR-koodi sijaitsevat kohteen %2 Ominaisuudet-sivulla."
+
+msgctxt "ConnectToRemoteAppDialog|"
+msgid "Automatically connect at %1 startup"
+msgstr "Yhdistä automaattisesti käynnistyksessä kohteeseen %1"
+
+msgctxt "ConnectToRemoteAppDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "ConnectToRemoteAppDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "ConnectToRemoteAppDialog|"
+msgid "Here you can connect to %1 running on your Windows/macOS/Linux PC"
+msgstr ""
+"Täällä voit yhdistää %1:iin, joka sijaitsee Windows/macOS/Linux ympäristössä"
+
+msgctxt "ConnectionsTab|"
+msgid "There are no connections"
+msgstr "Ei yhteyksiä"
+
+msgctxt "ConnectionsTab|"
+msgid "Host"
+msgstr "Palvelin"
+
+msgctxt "ConnectionsTab|"
+msgid "Port"
+msgstr "Portti"
+
+msgctxt "ConnectionsTab|"
+msgid "Connection count"
+msgstr "Yhteysmäärä"
+
+msgctxt "ConvertDestinationFilesExistsDialog|"
+msgid "Destination files already exists"
+msgstr "Kohdetiedosto on jo olemassa"
+
+msgctxt "ConvertDestinationFilesExistsDialog|"
+msgid "Overwrite All"
+msgstr "Päällekirjoita kaikki"
+
+msgctxt "ConvertDestinationFilesExistsDialog|"
+msgid "Rename All"
+msgstr "Nimeä kaikki uudelleen"
+
+msgctxt "ConvertDestinationFilesExistsDialog|"
+msgid "Skip All"
+msgstr "Ohita kaikki"
+
+msgctxt "ConvertDestinationFilesExistsDialog|"
+msgid "Abort"
+msgstr "Keskeytä"
+
+msgctxt "ConvertFilesFailedDialog|"
+msgid "Failed to convert"
+msgstr "Kääntäminen epäonnistui"
+
+msgctxt "ConvertFilesFailedDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "ConvertFilesFailedDialog|"
+msgid "Convert failed"
+msgstr "Kääntäminen epäonnistui"
+
+msgctxt "CopyLinkMenu|"
+msgid "Copy link"
+msgstr "Kopioi linkki"
+
+msgctxt "CopyMenu|"
+msgid "Copy"
+msgstr "Kopioi"
+
+msgctxt "CppQmlApp|"
+msgid "Are you sure you want to quit?"
+msgstr "Haluatko varmasti lopettaa?"
+
+msgctxt "CppQmlAppRcServer|"
+msgid "Starting..."
+msgstr "Käynnistetään..."
+
+msgctxt "CppQmlAppRcServer|"
+msgid "Failed to start."
+msgstr "Käynnistys epäonnistui."
+
+msgctxt "CppQmlAppRcServer|"
+msgid "Error: %1"
+msgstr "Virhe: %1"
+
+msgctxt "CppQmlAppRcServer|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "CrashReporter|"
+msgid ""
+"An internal error occurred.<br>%1 needs to be restarted for further use."
+msgstr "Sisäinen virhe havaittu.<br> %1 täytyy käynnistää uudelleen."
+
+msgctxt "CrashReporter|"
+msgid "Restart %1 automatically"
+msgstr "Uudelleenkäynnistä %1 automaattisesti"
+
+msgctxt "CrashReporter|"
+msgid "Failed to send the report.<br>Check your Internet connection."
+msgstr "Virheraportin lähetys epäonnistui.<br>Tarkista internetyhteytesi."
+
+msgctxt "CrashReporter|"
+msgid "Error"
+msgstr "Virhe"
+
+msgctxt "CreateFolderDialog|"
+msgid "Create folder"
+msgstr "Luo kansio"
+
+msgctxt "CreateFolderDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "CreateFolderDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "CreatePortableDialog|"
+msgid "Create portable version"
+msgstr "Luo siirrettävä versio"
+
+msgctxt "CreatePortableDialog|"
+msgid ""
+"Portable version of %1 can be used on different computers without the need "
+"to install and configure it on each of them."
+msgstr ""
+"Siirrettävää versiota %1:sta voidaan käyttää eri tietokoneilla ilman "
+"erillistä asennusta tai määrittämistä."
+
+msgctxt "CreatePortableDialog|"
+msgid "It can be conveniently placed on a flash disk, for example."
+msgstr "Sen voi sijoittaa esimerkiksi siirrettävälle USB-asemalle."
+
+msgctxt "CreatePortableDialog|"
+msgid ""
+"Specify here the path where you would like to create this version. It should "
+"be a folder on some removable drive."
+msgstr ""
+"Anna polku, johon haluat tämän version luotavan. Sen tulisi olla kansio "
+"siirrettävällä levyllä."
+
+msgctxt "CreatePortableDialog|"
+msgid "Open"
+msgstr "Avaa"
+
+msgctxt "CreatePortableDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "CreatePortableDialog|"
+msgid "Please specify the path."
+msgstr "Anna polku."
+
+msgctxt "CreatePortableDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "CreatePortableDialog|"
+msgid "Creating %1%"
+msgstr "Luodaan %1%"
+
+msgctxt "CreatePortableDialog|"
+msgid "An error occurred while creating a portable version: %1"
+msgstr "Virhe luotaessa siirrettävää versiota: %1"
+
+msgctxt "CreatePortableDialog|"
+msgid "Creating a portable version was successfully completed."
+msgstr "Siirrettävän version luominen onnistui."
+
+msgctxt "CreatePortableDialog|"
+msgid "Close"
+msgstr "Sulje"
+
+msgctxt "CustomizeSoundsDialog|"
+msgid "Customize sounds"
+msgstr "Muokkaa ääniä"
+
+msgctxt "CustomizeSoundsDialog|"
+msgid "Event"
+msgstr "Tapahtuma"
+
+msgctxt "CustomizeSoundsDialog|"
+msgid "Sound file"
+msgstr "Äänitiedosto"
+
+msgctxt "CustomizeSoundsDialog|"
+msgid "No sound"
+msgstr "Ei ääntä"
+
+msgctxt "CustomizeSoundsDialog|"
+msgid "Downloads added"
+msgstr "Lataus lisättiin"
+
+msgctxt "CustomizeSoundsDialog|"
+msgid "Downloads completed"
+msgstr "Lataus valmistui"
+
+msgctxt "CustomizeSoundsDialog|"
+msgid "Downloads failed"
+msgstr "Lataus epäonnistui"
+
+msgctxt "CustomizeSoundsDialog|"
+msgid "No active downloads"
+msgstr "Ei aktiivisia latauksia"
+
+msgctxt "CustomizeSoundsDialog|"
+msgid "Set sound"
+msgstr "Aseta ääni"
+
+msgctxt "CustomizeSoundsDialog|"
+msgid "Remove"
+msgstr "Poista"
+
+msgctxt "CustomizeSoundsDialog|"
+msgid "Test"
+msgstr "Testaa"
+
+msgctxt "CustomizeSoundsDialog|"
+msgid "Close"
+msgstr "Sulje"
+
+msgctxt "DeleteDownloadsDialog|"
+msgid "Delete selected downloads"
+msgstr "Poista valitut lataukset"
+
+msgctxt "DeleteDownloadsDialog|"
+msgid "Remember my choice"
+msgstr "Muista valinta"
+
+msgctxt "DeleteDownloadsDialog|"
+msgid "Delete files"
+msgstr "Poista tiedostot"
+
+msgctxt "DeleteDownloadsDialog|"
+msgid "Remove from list"
+msgstr "Poista listasta"
+
+msgctxt "DeleteDownloadsDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "DeleteDownloadsDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "DeleteDownloadsDialog|"
+msgid "Delete this file?"
+msgstr "Poista tämä tiedosto?"
+
+msgctxt "DeleteDownloadsDialog|"
+msgid "Delete selected files?"
+msgstr "Poista valitut tiedostot?"
+
+msgctxt "DeleteDownloadsDialogSimple|"
+msgid "Delete selected downloads"
+msgstr "Poista valitut lataukset"
+
+msgctxt "DeleteDownloadsDialogSimple|"
+msgid "Are you sure you want to delete the selected file(s)?"
+msgstr "Haluatko varmasti poistaa valitut tiedostot?"
+
+msgctxt "DeleteDownloadsDialogSimple|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "DeleteDownloadsDialogSimple|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "DeleteDownloadsFailedDialog|"
+msgid "Download deleting failed"
+msgstr "Latausten poistaminen epäonnistui"
+
+msgctxt "DeleteDownloadsFailedDialog|"
+msgid "Try again"
+msgstr "Yritä uudelleen"
+
+msgctxt "DeleteDownloadsFailedDialog|"
+msgid "Ignore"
+msgstr "Ohita"
+
+msgctxt "DeleteDownloadsFailedDialog|"
+msgid "Ignore all"
+msgstr "Ohita kaikki"
+
+msgctxt "DeleteDownloadsFailedDialog|"
+msgid "Abort"
+msgstr "Keskeytä"
+
+msgctxt "DiskSpace|"
+msgid "Size: %1 (Disk space: %2)"
+msgstr "Koko: %1 (Levytila: %2)"
+
+msgctxt "DiskSpace|"
+msgid "Size: %1"
+msgstr "Koko: %1"
+
+msgctxt "DockUploadSpeedSetting|"
+msgid "Show total upload speed in the Dock icon"
+msgstr "Näytä kokonaislähetysnopeus ilmoitusalueen kuvakkeessa"
+
+msgctxt "DownloadExpiredDialog|"
+msgid "Download Failure"
+msgstr "Lataus epäonnistui"
+
+msgctxt "DownloadExpiredDialog|"
+msgid ""
+"Can't resume download. Download link likely expired. Resume attempts failed."
+msgstr ""
+"Latausta ei voida jatkaa. Latauslinkki on todennäköisesti vanhentunut. "
+"Jatkoyritykset epäonnistuivat."
+
+msgctxt "DownloadExpiredDialog|"
+msgid "Please try to update the download link to resume."
+msgstr "Yritä päivittää latauslinkki jatkaaksesi."
+
+msgctxt "DownloadExpiredDialog|"
+msgid ""
+"Go to the website with the original download source and copy the renewed link"
+msgstr "Siirry alkuperäiselle lataussivustolle ja kopioi uusi linkki"
+
+msgctxt "DownloadExpiredDialog|"
+msgid "click here"
+msgstr "klikkaa tästä"
+
+msgctxt "DownloadExpiredDialog|"
+msgid "Update download"
+msgstr "Päivitä lataus"
+
+msgctxt "DownloadExpiredDialog|"
+msgid "Close"
+msgstr "Sulje"
+
+msgctxt "DownloadWindow|"
+msgid "[%1%] - %2"
+msgstr "[%1%] - %2"
+
+msgctxt "DownloadWindow|"
+msgid "Web page:"
+msgstr "Verkkosivu:"
+
+msgctxt "DownloadWindow|"
+msgid "Resource URL:"
+msgstr "Resurssin URL:"
+
+msgctxt "DownloadWindow|"
+msgid "Saved in"
+msgstr "Tallennettu"
+
+msgctxt "DownloadWindow|"
+msgid "File size"
+msgstr "Tiedostokoko"
+
+msgctxt "DownloadWindow|"
+msgid "Resume support"
+msgstr "Tukee jatkamista"
+
+msgctxt "DownloadWindow|"
+msgid "Yes"
+msgstr "Kyllä"
+
+msgctxt "DownloadWindow|"
+msgid "No"
+msgstr "Ei"
+
+msgctxt "DownloadWindow|"
+msgid "Unknown"
+msgstr "Ei tiedossa"
+
+msgctxt "DownloadWindow|"
+msgid "Downloaded"
+msgstr "Ladattu"
+
+msgctxt "DownloadWindow|"
+msgid "%1% [%2]"
+msgstr "%1% [%2]"
+
+msgctxt "DownloadWindow|"
+msgid "Speed"
+msgstr "Nopeus"
+
+msgctxt "DownloadWindow|"
+msgid "Time remaining"
+msgstr "Aikaa jäljellä"
+
+msgctxt "DownloadWindow|"
+msgid "Open download when it is completed"
+msgstr "Avaa lataus kun se valmistuu"
+
+msgctxt "DownloadWindow|"
+msgid "Close this window when the download is completed or stopped"
+msgstr "Sulje tämä ikkuna kun lataus valmistuu tai se pysäytetään"
+
+msgctxt "DownloadWindow|"
+msgid "Remember to always close by default"
+msgstr "Sulje aina"
+
+msgctxt "DownloadWindow|"
+msgid "Remember to never close by default"
+msgstr "Älä koskaan sulje"
+
+msgctxt "DownloadWindow|"
+msgid "Hide"
+msgstr "Piilota"
+
+msgctxt "DownloadWindow|"
+msgid "Show In Folder"
+msgstr "Näytä kansiossa"
+
+msgctxt "DownloadWindow|"
+msgid "Open"
+msgstr "Avaa"
+
+msgctxt "DownloadWindow|"
+msgid "Stop"
+msgstr "Pysäytä"
+
+msgctxt "DownloadWindow|"
+msgid "Start"
+msgstr "Aloita"
+
+msgctxt "DownloadsItemTools|"
+msgid "Moving"
+msgstr "Siirretään"
+
+msgctxt "DownloadsItemTools|"
+msgid "Checking for viruses"
+msgstr "Tarkistetaan viruksia"
+
+msgctxt "DownloadsItemTools|"
+msgid "Converting to mp3"
+msgstr "Käännetään mp3-muotoon"
+
+msgctxt "DownloadsItemTools|"
+msgid "Converting to mp4"
+msgstr "Käännetään mp4-muotoon"
+
+msgctxt "DownloadsItemTools|"
+msgid "Calculating hash"
+msgstr "Lasketaan tarkistussummaa"
+
+msgctxt "DownloadsItemTools|"
+msgid "File is missing"
+msgstr "Tiedosto puuttuu"
+
+msgctxt "DownloadsItemTools|"
+msgid "Disk is missing"
+msgstr "Levy puuttuu"
+
+msgctxt "DownloadsList|"
+msgid "Download links (%1 selected)"
+msgstr "Latauslinkit (%1 valittu)"
+
+msgctxt "DownloadsList|"
+msgid "Select all"
+msgstr "Valitse kaikki"
+
+msgctxt "DownloadsList|"
+msgid "Select none"
+msgstr "Poista valinnat"
+
+msgctxt "DownloadsPage|"
+msgid "Download list is empty."
+msgstr "Latauslista on tyhjä."
+
+msgctxt "DownloadsPage|"
+msgid "Add new download URL."
+msgstr "Lisää uuden latauksen URL."
+
+msgctxt "DownloadsPage|"
+msgid "No results found for"
+msgstr "Ei tuloksia kohteessa"
+
+msgctxt "DownloadsPage|"
+msgid "No results tagged \"%1\" found"
+msgstr "Ei tuloksia tägillä \"%1\""
+
+msgctxt "DownloadsPage|"
+msgid "No active downloads"
+msgstr "Ei aktiivisia latauksia"
+
+msgctxt "DownloadsPage|"
+msgid "No completed downloads"
+msgstr "Ei valmistuneita latauksia"
+
+msgctxt "DownloadsPage|"
+msgid "Show all"
+msgstr "Näytä kaikki"
+
+msgctxt "DownloadsPage|"
+msgid "Download list is empty. Add new download URL."
+msgstr "Latauslista on tyhjä. Lisää uuden latauksen URL."
+
+msgctxt "DownloadsPage|"
+msgid "Connect to remote %1"
+msgstr "Yhdistä etäyhteyteen %1"
+
+msgctxt "DownloadsSettings|"
+msgid "Downloads settings"
+msgstr "Latausasetukset"
+
+msgctxt "DownloadsSettings|"
+msgid "Start downloading without confirmation"
+msgstr "Aloita lataaminen ilman vahvistusta"
+
+msgctxt "DownloadsSettings|"
+msgid "Automatically remove deleted files from download list"
+msgstr "Poista poistetut tiedostot automaattisesti latauslistasta"
+
+msgctxt "DownloadsSettings|"
+msgid "Automatically remove completed downloads from download list"
+msgstr "Poista valmistuneet lataukset automaattisesti latauslistasta"
+
+msgctxt "DownloadsSettings|"
+msgid "Immediately"
+msgstr "Heti"
+
+msgctxt "DownloadsSettings|"
+msgid "In"
+msgstr " "
+
+msgctxt "DownloadsSettings|"
+msgid "days"
+msgstr "päivässä"
+
+msgctxt "DownloadsSettings|"
+msgid "Automatically retry failed downloads"
+msgstr "Yritä epäonnistuneita latauksia automaattisesti uudelleen"
+
+msgctxt "DownloadsSettings|"
+msgid "Detect unwanted behavior errors"
+msgstr "Havaitse epätoivotut käyttäytymisvirheet"
+
+msgctxt "DownloadsSettings|"
+msgid "Use server time for file creation"
+msgstr "Käytä palvelimen aikaa tiedoston luonnissa"
+
+msgctxt "DownloadsSettings|"
+msgid "Default download folder"
+msgstr "Oletuslatauskansio"
+
+msgctxt "DownloadsSettings|"
+msgid "Choose default download folder automatically"
+msgstr "Valitse oletuslatauskansio automaattisesti"
+
+msgctxt "DownloadsSettings|"
+msgid "Suggest folders based on file type"
+msgstr "Ehdota kansioita tiedostotyypistä"
+
+msgctxt "DownloadsSettings|"
+msgid "Suggest folders based on download URL"
+msgstr "Ehdota kansioita latauksen URL-osoitteesta"
+
+msgctxt "DownloadsSettings|"
+msgid "Fixed default download folder"
+msgstr "Muuttumaton oletuslatauskansio"
+
+msgctxt "DownloadsTagMenu|"
+msgid "Untag"
+msgstr "Poista tägi"
+
+msgctxt "DownloadsViewHeader|"
+msgid "Name"
+msgstr "Nimi"
+
+msgctxt "DownloadsViewHeader|"
+msgid "Status"
+msgstr "Tila"
+
+msgctxt "DownloadsViewHeader|"
+msgid "Speed"
+msgstr "Nopeus"
+
+msgctxt "DownloadsViewHeader|"
+msgid "Size"
+msgstr "Koko"
+
+msgctxt "DownloadsViewHeader|"
+msgid "Added"
+msgstr "Lisätty"
+
+msgctxt "DownloadsViewHeaderColumnsWidthCalc|"
+msgid "Paused"
+msgstr "Tauolla"
+
+msgctxt "DownloadsViewHeaderColumnsWidthCalc|"
+msgid "File is missing"
+msgstr "Tiedosto puuttuu"
+
+msgctxt "DownloadsViewHeaderColumnsWidthCalc|"
+msgid "Disk is missing"
+msgstr "Levy puuttuu"
+
+msgctxt "DownloadsViewHeaderColumnsWidthCalc|"
+msgid "Upload paused"
+msgstr "Lähetys tauolla"
+
+msgctxt "DownloadsViewItem|"
+msgid "Priority"
+msgstr "Tärkeys"
+
+msgctxt "DownloadsViewItem|"
+msgid "Upload paused"
+msgstr "Lähetys tauolla"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Restart"
+msgstr "Aloita alusta"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Open"
+msgstr "Avaa"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Show In Folder"
+msgstr "Näytä kansiossa"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Report problem"
+msgstr "Ilmoita ongelmasta"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Enable auto retry for this kind of errors"
+msgstr "Ota käyttöön automaattinen uudelleenyritys tälle virheelle"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Show Downloads"
+msgstr "Näytä lataukset"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Choose Files..."
+msgstr "Valitse tiedostot..."
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Set Priority"
+msgstr "Aseta tärkeys"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "High"
+msgstr "Korkea"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Normal"
+msgstr "Normaali"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Low"
+msgstr "Matala"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Rename file"
+msgstr "Nimeä tiedosto uudelleen"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Move to..."
+msgstr "Siirrä…"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Delete file"
+msgstr "Poista tiedosto"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Remove from list"
+msgstr "Poista listasta"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Sequential Download"
+msgstr "Lataus järjestyksessä"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Add mirror"
+msgstr "Lisää toisiopalvelin"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Open download page"
+msgstr "Avaa lataussivu"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Copy link"
+msgstr "Kopioi linkki"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Check for update"
+msgstr "Tarkista päivitykset"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Export selected downloads"
+msgstr "Vie valitut lataukset"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Add Tag"
+msgstr "Lisää tägi"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "File integrity"
+msgstr "Tiedostojen eheys"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Schedule"
+msgstr "Aikataulu"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Change URL"
+msgstr "Muuta URL-osoitetta"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Convert to mp3"
+msgstr "Käännä mp3-muotoon"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Convert to mp4"
+msgstr "Käännä mp4-muotoon"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Perform virus check"
+msgstr "Tarkista virusten varalta"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Abort"
+msgstr "Keskeytä"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Set priority"
+msgstr "Aseta tärkeys"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Show in folder"
+msgstr "Näytä kansiossa"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Show info"
+msgstr "Näytä tiedot"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Files"
+msgstr "Tiedostot"
+
+msgctxt "DownloadsViewItemContextMenu|"
+msgid "Sequential download"
+msgstr "Lataus järjestyksessä"
+
+msgctxt "DownloadsViewItemContextMenu2|"
+msgid "Remove from list"
+msgstr "Poista listasta"
+
+msgctxt "DownloadsViewItemFileInfo|"
+msgid "Download complete"
+msgstr "Lataus valmis"
+
+msgctxt "DownloadsViewItemFileInfo|"
+msgid "Checking files..."
+msgstr "Tarkistetaan tiedostoja…"
+
+msgctxt "DownloadsViewItemFileInfo|"
+msgid "Merging media streams..."
+msgstr "Yhdistetään mediastriimejä…"
+
+msgctxt "DownloadsViewItemFileInfo|"
+msgid "Requesting info..."
+msgstr "Pyydetään tietoja…"
+
+msgctxt "DownloadsViewItemFileInfo|"
+msgid "Queued"
+msgstr "Jonossa"
+
+msgctxt "DownloadsViewItemFileInfo|"
+msgid "Paused"
+msgstr "Tauolla"
+
+msgctxt "DownloadsViewItemFileInfo|"
+msgid "Unknown file size"
+msgstr "Tiedostokoko ei tiedossa"
+
+msgctxt "DownloadsViewStatusItem|"
+msgid "Queued"
+msgstr "Jonossa"
+
+msgctxt "DownloadsViewStatusItem|"
+msgid "Checking files"
+msgstr "Tarkistetaan tiedostoja"
+
+msgctxt "DownloadsViewStatusItem|"
+msgid "Merging media streams"
+msgstr "Yhdistetään mediastriimejä"
+
+msgctxt "DownloadsViewStatusItem|"
+msgid "Requesting info"
+msgstr "Pyydetään tietoja"
+
+msgctxt "DownloadsViewStatusItem|"
+msgid "Unknown file size"
+msgstr "Tiedostokoko ei tiedossa"
+
+msgctxt "DownloadsViewStatusItem|"
+msgid "Paused"
+msgstr "Tauolla"
+
+msgctxt "DownloadsViewStatusItem|"
+msgid "Complete"
+msgstr "Valmis"
+
+msgctxt "EditTagDialog|"
+msgid "Edit tag"
+msgstr "Muokkaa tägiä"
+
+msgctxt "EditTagDialog|"
+msgid "Tag"
+msgstr "Tägi"
+
+msgctxt "EditTagDialog|"
+msgid "Extensions (e.g. \"avi mp3\")"
+msgstr "Tiedostomuoto (.avi, .mp3, yms.)"
+
+msgctxt "EditTagDialog|"
+msgid ""
+"Extensions that are automatically assigned with this tag for new downloads"
+msgstr ""
+"Uusien latausten tiedostomuodot, jotka merkitään tällä tägillä "
+"automaattisesti"
+
+msgctxt "EditTagDialog|"
+msgid "Default download folder"
+msgstr "Oletuslatauskansio"
+
+msgctxt "EditTagDialog|"
+msgid "Open"
+msgstr "Avaa"
+
+msgctxt "EditTagDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "EditTagDialog|"
+msgid "Macros"
+msgstr "Makrot"
+
+msgctxt "EditTagDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "EnvTools|"
+msgid "Low battery"
+msgstr "Akku lopussa"
+
+msgctxt "EnvTools|"
+msgid "Data roaming disabled"
+msgstr "Roaming pois päältä"
+
+msgctxt "EnvTools|"
+msgid "No Internet connection"
+msgstr "Ei verkkoyhteyttä"
+
+msgctxt "EnvTools|"
+msgid "Mobile data use disabled"
+msgstr "Mobiilidata pois käytöstä"
+
+msgctxt "ExistingFileReactionCombobox|"
+msgid "Rename"
+msgstr "Nimeä uudelleen"
+
+msgctxt "ExistingFileReactionCombobox|"
+msgid "Overwrite"
+msgstr "Päällekirjoita"
+
+msgctxt "ExistingFileReactionCombobox|"
+msgid "Always ask"
+msgstr "Kysy erikseen"
+
+msgctxt "ExportDownloadsDialog|"
+msgid "Export selected downloads"
+msgstr "Vie valitut lataukset"
+
+msgctxt "ExportDownloadsDialog|"
+msgid "Export all downloads"
+msgstr "Vie kaikki lataukset"
+
+msgctxt "ExportDownloadsDialog|"
+msgid "Save to"
+msgstr "Tallenna nimellä"
+
+msgctxt "ExportDownloadsDialog|"
+msgid "Open"
+msgstr "Avaa"
+
+msgctxt "ExportDownloadsDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "ExportDownloadsDialog|"
+msgid "All files (%1)"
+msgstr "Kaikki tiedostot (%1)"
+
+msgctxt "ExportDownloadsDialog|"
+msgid "Export only completed downloads"
+msgstr "Vie vain valmistuneet lataukset"
+
+msgctxt "ExportDownloadsDialog|"
+msgid "Export"
+msgstr "Vie"
+
+msgctxt "ExportDownloadsTypeCombobox|"
+msgid "%1 downloads files (%2)"
+msgstr "%1 lataustiedostot (%2)"
+
+msgctxt "ExportDownloadsTypeCombobox|"
+msgid "Default format"
+msgstr "Oletusmuoto"
+
+msgctxt "ExportDownloadsTypeCombobox|"
+msgid "List of URLs"
+msgstr "URL-lista"
+
+msgctxt "ExportDownloadsTypeCombobox|"
+msgid "Text files (%1)"
+msgstr "Tekstitiedostot (%1)"
+
+msgctxt "ExportDownloadsTypeCombobox|"
+msgid "CSV file"
+msgstr "CSV-tiedosto"
+
+msgctxt "ExportDownloadsTypeCombobox|"
+msgid "CSV files (%1)"
+msgstr "CSV-tiedostot (%1)"
+
+msgctxt "ExportSettingsDialog|"
+msgid "Export"
+msgstr "Vie"
+
+msgctxt "ExportSettingsDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "ExportSettingsDialog|"
+msgid "%1 settings files (%2)"
+msgstr "%1 asetustiedostot (%2)"
+
+msgctxt "ExportSettingsDialog|"
+msgid "All files (%1)"
+msgstr "Kaikki tiedostot (%1)"
+
+msgctxt "FileIntegrityDialog|"
+msgid "Check file integrity"
+msgstr "Tarkista tiedostojen eheys"
+
+msgctxt "FileIntegrityDialog|"
+msgid "Hash"
+msgstr "Tarkistussumma"
+
+msgctxt "FileIntegrityDialog|"
+msgid "Calculating %1%"
+msgstr "Lasketaan %1%"
+
+msgctxt "FileIntegrityDialog|"
+msgid "Compare with"
+msgstr "Vertaa"
+
+msgctxt "FileIntegrityDialog|"
+msgid "Verification OK"
+msgstr "Tarkistus OK"
+
+msgctxt "FileIntegrityDialog|"
+msgid "Verification failed"
+msgstr "Tarkistus epäonnistui"
+
+msgctxt "FileIntegrityDialog|"
+msgid "Close"
+msgstr "Sulje"
+
+msgctxt "FileIntegrityPage|"
+msgid "Check file integrity"
+msgstr "Tarkista tiedostojen eheys"
+
+msgctxt "FileIntegrityPage|"
+msgid "MD5"
+msgstr "MD5"
+
+msgctxt "FileIntegrityPage|"
+msgid "SHA-1"
+msgstr "SHA-1"
+
+msgctxt "FileIntegrityPage|"
+msgid "SHA-256"
+msgstr "SHA-256"
+
+msgctxt "FileIntegrityPage|"
+msgid "SHA-512"
+msgstr "SHA-512"
+
+msgctxt "FileIntegrityPage|"
+msgid "Hash"
+msgstr "Tarkistussumma"
+
+msgctxt "FileIntegrityPage|"
+msgid "Calculating %1%"
+msgstr "Lasketaan %1%"
+
+msgctxt "FileIntegrityPage|"
+msgid "Compare with"
+msgstr "Vertaa"
+
+msgctxt "FileIntegrityPage|"
+msgid "Verification OK"
+msgstr "Tarkistus OK"
+
+msgctxt "FileIntegrityPage|"
+msgid "Verification failed"
+msgstr "Tarkistus epäonnistui"
+
+msgctxt "FileManagerSupportDialog|"
+msgid "No supported file managers found."
+msgstr "Ei tuettua tiedostonhallintaa."
+
+msgctxt "FileName|"
+msgid "Create subfolder"
+msgstr "Luo alikansio"
+
+msgctxt "FileName|"
+msgid "File name"
+msgstr "Tiedostonimi"
+
+msgctxt "FileName|"
+msgid "%1 files (*.%2)"
+msgstr "%1 tiedostot (*.%2)"
+
+msgctxt "FileName|"
+msgid "All files"
+msgstr "Kaikki tiedostot"
+
+msgctxt "FilePickerPage|"
+msgid "Select folder"
+msgstr "Valitse kansio"
+
+msgctxt "FilePickerPage|"
+msgid "Select file"
+msgstr "Valitse tiedosto"
+
+msgctxt "FilePickerPage|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "FilePickerPage|"
+msgid "Empty folder"
+msgstr "Uusi kansio"
+
+msgctxt "FilePickerSortDialog|"
+msgid "By date"
+msgstr "Päivämäärä"
+
+msgctxt "FilePickerSortDialog|"
+msgid "By name"
+msgstr "Nimi"
+
+msgctxt "FilePickerSortDialog|"
+msgid "By size"
+msgstr "Koko"
+
+msgctxt "FilePickerSortDialog|"
+msgid "Sort"
+msgstr "Järjestys"
+
+msgctxt "FilePickerSortDialog|"
+msgid "Ascending"
+msgstr "Nouseva"
+
+msgctxt "FilePickerSortDialog|"
+msgid "Descending"
+msgstr "Laskeva"
+
+msgctxt "FileType|"
+msgid "File type:"
+msgstr "Tiedostotyyppi:"
+
+msgctxt "FilesExistsDialog|"
+msgid "Warning: file exists already"
+msgstr "Varoitus: tiedosto on jo olemassa"
+
+msgctxt "FilesExistsDialog|"
+msgid "Remember my choice for all downloads"
+msgstr "Muista valintani kaikille latauksille"
+
+msgctxt "FilesExistsDialog|"
+msgid "Rename (%1)"
+msgstr "Nimeä uudelleen (%1)"
+
+msgctxt "FilesExistsDialog|"
+msgid "Overwrite"
+msgstr "Päällekirjoita"
+
+msgctxt "FilesExistsDialog|"
+msgid "Abort"
+msgstr "Keskeytä"
+
+msgctxt "FilesTree|"
+msgid "Name"
+msgstr "Nimi"
+
+msgctxt "FilesTree|"
+msgid "Size"
+msgstr "Koko"
+
+msgctxt "FilesTree|"
+msgid "Progress"
+msgstr "Edistys"
+
+msgctxt "FilesTree|"
+msgid "Priority"
+msgstr "Tärkeys"
+
+msgctxt "FilesTree|"
+msgid "Normal"
+msgstr "Normaali"
+
+msgctxt "FilesTree|"
+msgid "High"
+msgstr "Korkea"
+
+msgctxt "FilesTree|"
+msgid "Low"
+msgstr "Matala"
+
+msgctxt "FilesTree|"
+msgid "Files"
+msgstr "Tiedostot"
+
+msgctxt "FilesTree|"
+msgid "Select all"
+msgstr "Valitse kaikki"
+
+msgctxt "FilesTree|"
+msgid "Select none"
+msgstr "Poista valinnat"
+
+msgctxt "FilesTreeContextMenu|"
+msgid "High Priority"
+msgstr "Korkea tärkeys"
+
+msgctxt "FilesTreeContextMenu|"
+msgid "Normal Priority"
+msgstr "Normaali tärkeys"
+
+msgctxt "FilesTreeContextMenu|"
+msgid "Low Priority"
+msgstr "Matala tärkeys"
+
+msgctxt "FilesTreeContextMenu|"
+msgid "Skip"
+msgstr "Ohita"
+
+msgctxt "FilesTreeContextMenu|"
+msgid "Open"
+msgstr "Avaa"
+
+msgctxt "FilesTreeContextMenu|"
+msgid "Show in Folder"
+msgstr "Näytä kansiossa"
+
+msgctxt "FilesTreeContextMenu|"
+msgid "File Integrity"
+msgstr "Tiedostojen eheys"
+
+msgctxt "FilesTreeContextMenu|"
+msgid "Convert video to mp3"
+msgstr "Käännä video mp3-muotoon"
+
+msgctxt "FilesTreeContextMenu|"
+msgid "Convert video to mp4"
+msgstr "Käännä video mp4-muotoon"
+
+msgctxt "FilesTreeContextMenu|"
+msgid "Convert to mp4"
+msgstr "Käännä mp4-muotoon"
+
+msgctxt "FixedDownloadFolderCombobox|"
+msgid "Macros"
+msgstr "Makrot"
+
+msgctxt "GeneralSettings|"
+msgid "General"
+msgstr "Yleinen"
+
+msgctxt "GeneralSettings|"
+msgid "Choose theme"
+msgstr "Valitse teema"
+
+msgctxt "GeneralSettings|"
+msgid "Language"
+msgstr "Kieli"
+
+msgctxt "GeneralSettings|"
+msgid "Downloads"
+msgstr "Lataukset"
+
+msgctxt "GeneralSettings|"
+msgid "Suggest folders based on file type"
+msgstr "Ehdota kansioita tiedostotyypistä"
+
+msgctxt "GeneralSettings|"
+msgid "A light theme will be used, if the system theme is unknown."
+msgstr "Vaaleaa teemaa käytetään, jos järjestelmäteema ei ole tiedossa."
+
+msgctxt "GeneralSettings|"
+msgid "Your language is not listed or the translation isn't complete?"
+msgstr "Puutteellinen käännös?"
+
+msgctxt "GeneralSettings|"
+msgid "Let's fix it!"
+msgstr "Korjataanpa asia!"
+
+msgctxt "GeneralSettings|"
+msgid "Default download folder"
+msgstr "Oletuslatauskansio"
+
+msgctxt "GeneralSettings|"
+msgid "Choose default download folder automatically"
+msgstr "Valitse oletuslatauskansio automaattisesti"
+
+msgctxt "GeneralSettings|"
+msgid "Suggest folders based on download URL"
+msgstr "Ehdota kansioita latauksen URL-osoitteesta"
+
+msgctxt "GeneralSettings|"
+msgid "Fixed default download folder"
+msgstr "Muuttumaton oletuslatauskansio"
+
+msgctxt "GeneralSettings|"
+msgid "Open"
+msgstr "Avaa"
+
+msgctxt "GeneralSettings|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "GeneralSettings|"
+msgid "Macros"
+msgstr "Makrot"
+
+msgctxt "GeneralSettings|"
+msgid "Compact view of downloads list"
+msgstr "Kompakti latauslista"
+
+msgctxt "GeneralSettings|"
+msgid "Enable standalone downloads windows"
+msgstr "Ota käyttöön latausten itsenäiset ikkunat"
+
+msgctxt "GeneralSettings|"
+msgid "Automatically remove deleted files from download list"
+msgstr "Poista poistetut tiedostot automaattisesti latauslistasta"
+
+msgctxt "GeneralSettings|"
+msgid "Automatically remove completed downloads from download list"
+msgstr "Poista valmistuneet lataukset automaattisesti latauslistasta"
+
+msgctxt "GeneralSettings|"
+msgid "Immediately"
+msgstr "Heti"
+
+msgctxt "GeneralSettings|"
+msgid "In"
+msgstr " "
+
+msgctxt "GeneralSettings|"
+msgid "days"
+msgstr "päivässä"
+
+msgctxt "GeneralSettings|"
+msgid "Automatically retry failed downloads"
+msgstr "Yritä epäonnistuneita latauksia automaattisesti uudelleen"
+
+msgctxt "GeneralSettings|"
+msgid "Detect unwanted behavior errors"
+msgstr "Havaitse epätoivotut käyttäytymisvirheet"
+
+msgctxt "GeneralSettings|"
+msgid "Use server time for file creation"
+msgstr "Käytä palvelimen aikaa tiedoston luonnissa"
+
+msgctxt "GeneralSettings|"
+msgid "Maximum urls count in batch download"
+msgstr "URL-osoitteiden enimmäismäärä monilatauksessa"
+
+msgctxt "GeneralSettings|"
+msgid "Update"
+msgstr "Päivitä"
+
+msgctxt "GeneralSettings|"
+msgid "Check for updates automatically"
+msgstr "Tarkista päivitykset automaattisesti"
+
+msgctxt "GeneralSettings|"
+msgid "Install updates automatically"
+msgstr "Asenna päivitykset automaattisesti"
+
+msgctxt "GeneralSettings2|"
+msgid "Check for updates automatically"
+msgstr "Tarkista päivitykset automaattisesti"
+
+msgctxt "GeneralSettings2|"
+msgid "Install updates automatically"
+msgstr "Asenna päivitykset automaattisesti"
+
+msgctxt "GeneralSettings2|"
+msgid "Use mobile network"
+msgstr "Käytä mobiilidataa"
+
+msgctxt "GeneralSettings2|"
+msgid "Allow data roaming"
+msgstr "Salli Roaming"
+
+msgctxt "GeneralSettings2|"
+msgid "Using mobile data while roaming may result in additional charges."
+msgstr ""
+"Mobiilidatan käyttö Roaming-verkossa saattaa aiheuttaa lisäkustannuksia."
+
+msgctxt "GeneralTab|"
+msgid "Status"
+msgstr "Tila"
+
+msgctxt "GeneralTab|"
+msgid "completed"
+msgstr "valmis"
+
+msgctxt "GeneralTab|"
+msgid "State"
+msgstr "Tila"
+
+msgctxt "GeneralTab|"
+msgid "Total size:"
+msgstr "Koko:"
+
+msgctxt "GeneralTab|"
+msgid "Downloaded:"
+msgstr "Ladattu:"
+
+msgctxt "GeneralTab|"
+msgid "Uploaded"
+msgstr "Lähetetty"
+
+msgctxt "GeneralTab|"
+msgid "ratio"
+msgstr "suhde"
+
+msgctxt "GeneralTab|"
+msgid "Web page"
+msgstr "Verkkosivu"
+
+msgctxt "GeneralTab|"
+msgid "File"
+msgstr "Tiedosto"
+
+msgctxt "GeneralTab|"
+msgid "Speed"
+msgstr "Nopeus"
+
+msgctxt "GeneralTab|"
+msgid "Download speed:"
+msgstr "Latausnopeus:"
+
+msgctxt "GeneralTab|"
+msgid "Upload speed:"
+msgstr "Lähetysnopeus:"
+
+msgctxt "GeneralTab|"
+msgid "Added at:"
+msgstr "Lisätty:"
+
+# Needs more context.
+msgctxt "GeneralTab|"
+msgid "%1 of %2"
+msgstr ""
+
+msgctxt "GeneralTab|"
+msgid "Domain:"
+msgstr "Osoite:"
+
+msgctxt "GeneralTab|"
+msgid "Added:"
+msgstr "Lisätty:"
+
+msgctxt "GeneralTab|"
+msgid "Progress:"
+msgstr "Edistys:"
+
+msgctxt "HashAlgorithmCombobox|"
+msgid "MD5"
+msgstr "MD5"
+
+msgctxt "HashAlgorithmCombobox|"
+msgid "SHA-1"
+msgstr "SHA-1"
+
+msgctxt "HashAlgorithmCombobox|"
+msgid "SHA-256"
+msgstr "SHA-256"
+
+msgctxt "HashAlgorithmCombobox|"
+msgid "SHA-512"
+msgstr "SHA-512"
+
+msgctxt "ImportDialog|"
+msgid "Import"
+msgstr "Tuo"
+
+msgctxt "ImportDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "ImportDialog|"
+msgid "All files (%1)"
+msgstr "Kaikki tiedostot (%1)"
+
+msgctxt "ImportDialog|"
+msgid "Text files (%1)"
+msgstr "Tekstitiedostot (%1)"
+
+msgctxt "ImportDialog|"
+msgid "%1 downloads files (%2)"
+msgstr "%1 lataustiedostot (%2)"
+
+msgctxt "ImportDialog|"
+msgid "%1 settings files (%2)"
+msgstr "%1 asetustiedostot (%2)"
+
+msgctxt "ImportExportFailedDialog|"
+msgid "Error: %1"
+msgstr "Virhe: %1"
+
+msgctxt "ImportExportFailedDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "ImportExportFailedDialog|"
+msgid "Failure to paste URLs from the file"
+msgstr "Tuonti tiedostosta epäonnistui"
+
+msgctxt "ImportExportFailedDialog|"
+msgid "Unable to import the list of URLs from the file: %1"
+msgstr "URL-osoitteiden listan tuonti tiedostosta epäonnistui: %1"
+
+msgctxt "ImportExportFailedDialog|"
+msgid "Failure to export"
+msgstr "Vienti epäonnistui"
+
+msgctxt "ImportExportFailedDialog|"
+msgid "Unable to export to the file: %1"
+msgstr "Vienti tiedostoon epäonnistui: %1"
+
+msgctxt "ImportExportFailedDialog|"
+msgid "Failure to import"
+msgstr "Tuonti epäonnistui"
+
+msgctxt "ImportExportFailedDialog|"
+msgid "Unable to import from the file: %1"
+msgstr "Tuonti tiedostosta epäonnistui: %1"
+
+msgctxt "IntegrationBanner|"
+msgid "Set as Default"
+msgstr "Aseta oletukseksi"
+
+msgctxt "IntegrationBanner|"
+msgid "Don't ask again"
+msgstr "Älä kysy uudelleen"
+
+msgctxt "InvalidSettingsMessageDialog|"
+msgid ". Close anyway?"
+msgstr ". Sulje silti?"
+
+msgctxt "LanguageDialog|"
+msgid "Language"
+msgstr "Kieli"
+
+msgctxt "LeftDrawer|"
+msgid "remote control"
+msgstr "etähallinta"
+
+msgctxt "LeftDrawer|"
+msgid "Browser"
+msgstr "Selain"
+
+msgctxt "LeftDrawer|"
+msgid "Settings"
+msgstr "Asetukset"
+
+msgctxt "LeftDrawer|"
+msgid "Contact support"
+msgstr "Tuki"
+
+msgctxt "LeftDrawer|"
+msgid "Disconnect from remote %1"
+msgstr "Katkaise etäyhteys kohteeseen %1"
+
+msgctxt "LeftDrawer|"
+msgid "Connect to remote %1"
+msgstr "Ota etäyhteys kohteeseen %1"
+
+msgctxt "LeftDrawer|"
+msgid "About"
+msgstr "Tietoja"
+
+msgctxt "LeftDrawer|"
+msgid "Quit"
+msgstr "Lopeta"
+
+msgctxt "LeftDrawer|"
+msgid "Add new download"
+msgstr "Lisää uusi lataus"
+
+msgctxt "ListEditor|"
+msgid "Add"
+msgstr "Lisää"
+
+msgctxt "ListEditor|"
+msgid "Hide"
+msgstr "Piilota"
+
+msgctxt "MacrosMenu|"
+msgid "%content_type% - content type (e.g. \"Music\")"
+msgstr "%content_type% - sisällön tyyppi (esim. \"musiikki\")"
+
+msgctxt "MacrosMenu|"
+msgid "%server% - name of the server (e.g. \"%1\")"
+msgstr "%server% - palvelimen nimi (esim. \"%1\")"
+
+msgctxt "MacrosMenu|"
+msgid "%path_on_server% - path to the downloading file on the server"
+msgstr "%path_on_server% - ladattavan tiedoston polku palvelimella"
+
+msgctxt "MacrosMenu|"
+msgid "%year% - current year"
+msgstr "%year% - nykyinen vuosi"
+
+msgctxt "MacrosMenu|"
+msgid "%month% - current month (number from 1 to 12)"
+msgstr "%month% - nykyinen kuukausi (numerona 1-12)"
+
+msgctxt "MacrosMenu|"
+msgid "%day% - current day"
+msgstr "%day% - nykyinen päivä"
+
+msgctxt "MacrosMenu|"
+msgid "%date% - equivalent to %year%-%month%-%day%"
+msgstr "%date% - sama kuin %year%-%month%-%day%"
+
+msgctxt "MainFiltersBar|"
+msgid "All"
+msgstr "Kaikki"
+
+msgctxt "MainFiltersBar|"
+msgid "Missing Files"
+msgstr "Puuttuvat tiedostot"
+
+msgctxt "MainFiltersBar|"
+msgid "Active"
+msgstr "Aktiivinen"
+
+msgctxt "MainFiltersBar|"
+msgid "Completed"
+msgstr "Valmis"
+
+msgctxt "MainFiltersBar|"
+msgid "Uncompleted"
+msgstr "Kesken"
+
+msgctxt "MainFiltersBar|"
+msgid "OK to remove tag?"
+msgstr "Voidaanko tägi poistaa?"
+
+msgctxt "MainMenu|"
+msgid "Paste Urls from Clipboard"
+msgstr "Liitä URL:t leikepöydältä"
+
+msgctxt "MainMenu|"
+msgid "Paste Urls from File"
+msgstr "Liitä URL:t tiedostosta"
+
+msgctxt "MainMenu|"
+msgid "Export/Import"
+msgstr "Vie/tuo"
+
+msgctxt "MainMenu|"
+msgid "Export all downloads"
+msgstr "Vie kaikki lataukset"
+
+msgctxt "MainMenu|"
+msgid "Import downloads"
+msgstr "Tuo lataukset"
+
+msgctxt "MainMenu|"
+msgid "Export settings"
+msgstr "Vie asetukset"
+
+msgctxt "MainMenu|"
+msgid "Import settings"
+msgstr "Tuo asetukset"
+
+msgctxt "MainMenu|"
+msgid "Add-ons..."
+msgstr "Laajennukset…"
+
+msgctxt "MainMenu|"
+msgid "Preferences..."
+msgstr "Asetukset…"
+
+msgctxt "MainMenu|"
+msgid "Contact Support"
+msgstr "Tuki"
+
+msgctxt "MainMenu|"
+msgid "Auto Shutdown"
+msgstr "Automaattinen sammutus"
+
+msgctxt "MainMenu|"
+msgid "Sleep"
+msgstr "Lepotila"
+
+msgctxt "MainMenu|"
+msgid "Hibernate"
+msgstr "Horrostila"
+
+msgctxt "MainMenu|"
+msgid "Shutdown"
+msgstr "Sammuta"
+
+msgctxt "MainMenu|"
+msgid "Disconnect from remote %1"
+msgstr "Katkaise etäyhteys kohteeseen %1"
+
+msgctxt "MainMenu|"
+msgid "Connect to remote %1"
+msgstr "Ota etäyhteys kohteeseen %1"
+
+msgctxt "MainMenu|"
+msgid "Create portable version"
+msgstr "Luo siirrettävä versio"
+
+msgctxt "MainMenu|"
+msgid "Check for Updates..."
+msgstr "Tarkista päivitykset…"
+
+msgctxt "MainMenu|"
+msgid "Join the Mosaic..."
+msgstr "Liity Mosaiikkiin…"
+
+msgctxt "MainMenu|"
+msgid "About"
+msgstr "Tietoja"
+
+msgctxt "MainMenu|"
+msgid "Quit"
+msgstr "Lopeta"
+
+msgctxt "MainStatusBar|"
+msgid "Snail mode frees bandwidth without stopping downloads."
+msgstr "Etanatila vapauttaa kaistanleveyttä ilman latausten pysäyttämistä."
+
+msgctxt "MainStatusBar|"
+msgid "Snail mode"
+msgstr "Etanatila"
+
+msgctxt "MainStatusBar|"
+msgid "%n downloads selected."
+msgid_plural "%n downloads selected."
+msgstr[0] "%n lataus valittu."
+msgstr[1] "%n latausta valittu."
+
+msgctxt "MainStatusBar|"
+msgid "Total size:"
+msgstr "Koko:"
+
+msgctxt "MainToolbar|"
+msgid "Add new download..."
+msgstr "Lisää uusi lataus…"
+
+msgctxt "MainToolbar|"
+msgid "Start all"
+msgstr "Aloita kaikki"
+
+msgctxt "MainToolbar|"
+msgid "Start selected"
+msgstr "Aloita valitut"
+
+msgctxt "MainToolbar|"
+msgid "Pause all"
+msgstr "Tauota kaikki"
+
+msgctxt "MainToolbar|"
+msgid "Pause selected"
+msgstr "Tauota valitut"
+
+msgctxt "MainToolbar|"
+msgid "Delete selected"
+msgstr "Poista valitut"
+
+msgctxt "MainToolbar|"
+msgid "Move to..."
+msgstr "Siirrä…"
+
+msgctxt "MainToolbar|"
+msgid "Move downloads up"
+msgstr "Siirrä lataukset ylös"
+
+msgctxt "MainToolbar|"
+msgid "Move downloads down"
+msgstr "Siirrä lataukset alas"
+
+msgctxt "MainToolbar|"
+msgid "Main menu"
+msgstr "Päävalikko"
+
+msgctxt "MainToolbar|"
+msgid "Switch to user-defined sorting of the download list?"
+msgstr "Vaihda käyttäjän määrittelemään latausvalikon järjestykseen?"
+
+msgctxt "MainToolbar|"
+msgid "remote control"
+msgstr "etähallinta"
+
+msgctxt "MaxURatioComboBox|"
+msgid "Unlimited"
+msgstr "Rajoittamaton"
+
+msgctxt "MaxURatioComboBox|"
+msgid "Custom..."
+msgstr "Muu…"
+
+msgctxt "MaxURatioComboBox|"
+msgid "Custom value"
+msgstr "Muu arvo"
+
+msgctxt "MaxURatioComboBox|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "MaxURatioComboBox|"
+msgid "CANCEL"
+msgstr "PERU"
+
+msgctxt "MaxURatioComboBox|"
+msgid "Invalid value"
+msgstr "Virheellinen arvo"
+
+msgctxt "MaxURatioComboBox|"
+msgid "Must be a number greater than 0."
+msgstr "Arvon tulee olla nollaa suurempi numero."
+
+msgctxt "MergeDownloadsDialog|"
+msgid "The download already exists"
+msgstr "Lataus on jo olemassa"
+
+msgctxt "MergeDownloadsDialog|"
+msgid "URL:"
+msgstr "URL:"
+
+msgctxt "MergeDownloadsDialog|"
+msgid "Path:"
+msgstr "Polku:"
+
+msgctxt "MergeDownloadsDialog|"
+msgid "Size:"
+msgstr "Koko:"
+
+msgctxt "MergeDownloadsDialog|"
+msgid "Added at:"
+msgstr "Lisätty:"
+
+msgctxt "MergeDownloadsDialog|"
+msgid "Skip"
+msgstr "Ohita"
+
+msgctxt "MergeDownloadsDialog|"
+msgid "Skip all (%1)"
+msgstr "Ohita kaikki (%1)"
+
+msgctxt "MergeDownloadsDialog|"
+msgid "Download"
+msgstr "Lataa"
+
+msgctxt "MobileDataUsageDialog|"
+msgid "Mobile data usage"
+msgstr "Mobiilidatan käyttö"
+
+msgctxt "MobileDataUsageDialog|"
+msgid "Waiting for Wi-Fi to start download."
+msgstr "Odotetaan Wi-Fi -yhteyttä lataamiseen."
+
+msgctxt "MobileDataUsageDialog|"
+msgid "Would you like to enable usage of mobile data? *"
+msgstr "Haluatko käyttää mobiilidataa? *"
+
+msgctxt "MobileDataUsageDialog|"
+msgid "Don't ask again"
+msgstr "Älä kysy uudelleen"
+
+msgctxt "MobileDataUsageDialog|"
+msgid "Yes"
+msgstr "Kyllä"
+
+msgctxt "MobileDataUsageDialog|"
+msgid "No"
+msgstr "Ei"
+
+msgctxt "MobileDataUsageDialog|"
+msgid "* additional charges may apply"
+msgstr "* lisämaksuja saatetaan periä"
+
+msgctxt "MovingFailedDialog|"
+msgid "Moving download failed"
+msgstr "Latauksen siirtäminen epäonnistui"
+
+msgctxt "MovingFailedDialog|"
+msgid "Error: %1"
+msgstr "Virhe: %1"
+
+msgctxt "MovingFailedDialog|"
+msgid "Unable to move: %1"
+msgstr "Ei voitu siirtää: %1"
+
+msgctxt "MovingFailedDialog|"
+msgid "Try again"
+msgstr "Yritä uudelleen"
+
+msgctxt "MovingFailedDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "MovingFolderDialog|"
+msgid "Move"
+msgstr "Siirrä"
+
+msgctxt "MovingFolderDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "Mp3ConverterDialog|"
+msgid "Convert to mp3 with adjustable bitrate"
+msgstr "Käännä mp3-muotoon muuttuvalla bittinopeudella"
+
+msgctxt "Mp3ConverterDialog|"
+msgid "Save to"
+msgstr "Tallenna nimellä"
+
+msgctxt "Mp3ConverterDialog|"
+msgid "Open"
+msgstr "Avaa"
+
+msgctxt "Mp3ConverterDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "Mp3ConverterDialog|"
+msgid "Bitrate (quality)"
+msgstr "Bittinopeus (laatu)"
+
+msgctxt "Mp3ConverterDialog|"
+msgid "Constant bitrate of value"
+msgstr "Vakaa bittinopeus"
+
+msgctxt "Mp3ConverterDialog|"
+msgid "Variable bitrate (VBR)"
+msgstr "Muuttuva bittinopeus (VBR)"
+
+msgctxt "Mp3ConverterDialog|"
+msgid "The path contains invalid characters"
+msgstr "Polku sisältää kiellettyjä merkkejä"
+
+msgctxt "Mp3ConverterDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "Mp3ConverterPage|"
+msgid "Convert to mp3"
+msgstr "Käännä mp3-muotoon"
+
+msgctxt "Mp3ConverterPage|"
+msgid "Convert to mp3 with adjustable bitrate"
+msgstr "Käännä mp3-muotoon muuttuvalla bittinopeudella"
+
+msgctxt "Mp3ConverterPage|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "Mp3ConverterPage|"
+msgid "Save to"
+msgstr "Tallenna nimellä"
+
+msgctxt "Mp3ConverterPage|"
+msgid "The path contains invalid characters"
+msgstr "Polku sisältää kiellettyjä merkkejä"
+
+msgctxt "Mp3ConverterPage|"
+msgid "Bitrate (quality)"
+msgstr "Bittinopeus (laatu)"
+
+msgctxt "Mp3ConverterPage|"
+msgid "Constant bitrate of value"
+msgstr "Vakaa bittinopeus"
+
+msgctxt "Mp3ConverterPage|"
+msgid "Variable bitrate (VBR)"
+msgstr "Muuttuva bittinopeus (VBR)"
+
+msgctxt "Mp4ConverterDialog|"
+msgid "Convert to mp4"
+msgstr "Käännä mp4-muotoon"
+
+msgctxt "Mp4ConverterDialog|"
+msgid "Save to"
+msgstr "Tallenna nimellä"
+
+msgctxt "Mp4ConverterDialog|"
+msgid "Open"
+msgstr "Avaa"
+
+msgctxt "Mp4ConverterDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "Mp4ConverterDialog|"
+msgid "The path contains invalid characters"
+msgstr "Polku sisältää kiellettyjä merkkejä"
+
+msgctxt "Mp4ConverterDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "Mp4ConverterPage|"
+msgid "Convert to mp4"
+msgstr "Käännä mp4-muotoon"
+
+msgctxt "Mp4ConverterPage|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "Mp4ConverterPage|"
+msgid "Save to"
+msgstr "Tallenna nimellä"
+
+msgctxt "Mp4ConverterPage|"
+msgid "The path contains invalid characters"
+msgstr "Polku sisältää kiellettyjä merkkejä"
+
+msgctxt "NativeMenuBar|"
+msgid "Check for Updates..."
+msgstr "Tarkista päivitykset…"
+
+msgctxt "NativeMenuBar|"
+msgid "Preferences..."
+msgstr "Asetukset…"
+
+msgctxt "NativeMenuBar|"
+msgid "Quit"
+msgstr "Lopeta"
+
+msgctxt "NativeMenuBar|"
+msgid "&File"
+msgstr "&Tiedosto"
+
+msgctxt "NativeMenuBar|"
+msgid "Add &new download"
+msgstr "Lisää &uusi lataus"
+
+msgctxt "NativeMenuBar|"
+msgid "&Edit"
+msgstr "&Muokkaa"
+
+msgctxt "NativeMenuBar|"
+msgid "&Copy"
+msgstr "&Kopioi"
+
+msgctxt "NativeMenuBar|"
+msgid "&Paste"
+msgstr "&Liitä"
+
+msgctxt "NativeMenuBar|"
+msgid "Downloads"
+msgstr "Lataukset"
+
+msgctxt "NativeMenuBar|"
+msgid "Start selected"
+msgstr "Aloita valitut"
+
+msgctxt "NativeMenuBar|"
+msgid "Pause selected"
+msgstr "Tauota valitut"
+
+msgctxt "NativeMenuBar|"
+msgid "Restart selected"
+msgstr "Aloita valitut alusta"
+
+msgctxt "NativeMenuBar|"
+msgid "Remove from List"
+msgstr "Poista listasta"
+
+msgctxt "NativeMenuBar|"
+msgid "Help"
+msgstr "Apua"
+
+msgctxt "NativeMenuBar|"
+msgid "Contact Support"
+msgstr "Tuki"
+
+msgctxt "NetworkSettings|"
+msgid "Network"
+msgstr "Verkko"
+
+msgctxt "NetworkSettings|"
+msgid "Proxy"
+msgstr "Välityspalvelin"
+
+msgctxt "NetworkSettings|"
+msgid "System proxy"
+msgstr "Järjestelmän välityspalvelin"
+
+msgctxt "NetworkSettings|"
+msgid "No proxy"
+msgstr "Ei välityspalvelinta"
+
+msgctxt "NetworkSettings|"
+msgid "Configure manually:"
+msgstr "Aseta manuaalisesti:"
+
+msgctxt "NetworkSettings|"
+msgid "Address"
+msgstr "Osoite"
+
+msgctxt "NetworkSettings|"
+msgid "Port"
+msgstr "Portti"
+
+msgctxt "NetworkSettings|"
+msgid "HTTP:"
+msgstr "HTTP:"
+
+msgctxt "NetworkSettings|"
+msgid ":"
+msgstr ":"
+
+msgctxt "NetworkSettings|"
+msgid "HTTPS:"
+msgstr "HTTPS:"
+
+msgctxt "NetworkSettings|"
+msgid "FTP:"
+msgstr "FTP:"
+
+msgctxt "NetworkSettings|"
+msgid "SOCKS5:"
+msgstr "SOCKS5:"
+
+msgctxt "NetworkSettings|"
+msgid "Invalid proxy settings"
+msgstr "Virheelliset välityspalvelimen asetukset"
+
+msgctxt "NetworkSettings|"
+msgid "Proxy settings"
+msgstr "Välityspalvelimen asetukset"
+
+msgctxt "NetworkSettings|"
+msgid "HTTP"
+msgstr "HTTP"
+
+msgctxt "NetworkSettings|"
+msgid "HTTPS"
+msgstr "HTTPS"
+
+msgctxt "NetworkSettings|"
+msgid "FTP"
+msgstr "FTP"
+
+msgctxt "NetworkSettings|"
+msgid "SOCKS5"
+msgstr "SOCKS5"
+
+msgctxt "NetworkSpeedLimitComboBox|"
+msgid "Unlimited"
+msgstr "Rajoittamaton"
+
+msgctxt "NetworkSpeedLimitComboBox|"
+msgid "Custom..."
+msgstr "Muu…"
+
+msgctxt "NetworkSpeedLimitComboBox|"
+msgid "KB/s"
+msgstr "KB/s"
+
+msgctxt "NetworkSpeedLimitComboBox|"
+msgid "Please enter numbers only"
+msgstr "Syötä vain numeroita"
+
+msgctxt "NetworkSpeedLimitComboBox|"
+msgid "Custom value"
+msgstr "Muu arvo"
+
+msgctxt "NetworkSpeedLimitComboBox|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "NetworkSpeedLimitComboBox|"
+msgid "CANCEL"
+msgstr "PERU"
+
+msgctxt "NetworkSpeedLimitComboBox|"
+msgid "Invalid value"
+msgstr "Virheellinen arvo"
+
+msgctxt "NetworkSpeedLimitComboBox|"
+msgid "Must be a number greater than 0."
+msgstr "Arvon tulee olla nollaa suurempi numero."
+
+msgctxt "Page|"
+msgid "Info"
+msgstr "Tietoja"
+
+msgctxt "Page|"
+msgid "Files"
+msgstr "Tiedostot"
+
+msgctxt "Page|"
+msgid "Connections"
+msgstr "Yhteydet"
+
+msgctxt "PluginsDepsInstallerView|"
+msgid "Installed."
+msgstr "Asennettu."
+
+msgctxt "PluginsPage|"
+msgid "Recently installed dependency"
+msgstr "Uudet asennetut riippuvuudet"
+
+msgctxt "PluginsPage|"
+msgid "Add-ons"
+msgstr "Laajennukset"
+
+msgctxt "PluginsPage|"
+msgid "Check for Updates"
+msgstr "Tarkista päivitykset"
+
+msgctxt "PluginsPage|"
+msgid "Install Add-on From File..."
+msgstr "Asenna laajennus tiedostosta…"
+
+msgctxt "PluginsPage|"
+msgid "Update Add-ons Automatically"
+msgstr "Päivitä laajennukset automaattisesti"
+
+msgctxt "PluginsPage|"
+msgid "Reset All Add-ons to Update Automatically"
+msgstr "Aseta kaikki laajennukset päivittymään automaattisesti"
+
+msgctxt "PluginsPage|"
+msgid "Updating installed add-ons..."
+msgstr "Päivitetään asennettuja laajennuksia…"
+
+msgctxt "PluginsPage|"
+msgid "There are no installed add-ons."
+msgstr "Ei asennettuja laajennuksia."
+
+msgctxt "PluginsPage|"
+msgid "Install add-on from file"
+msgstr "Asenna laajennus tiedostosta"
+
+msgctxt "PluginsPage|"
+msgid "Learn more about %1 add-ons"
+msgstr "Lue lisää %1 laajennuksista"
+
+msgctxt "PluginsPage|"
+msgid "Install"
+msgstr "Asenna"
+
+msgctxt "PluginsPage|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "PluginsPage|"
+msgid "%1 add-ons files"
+msgstr "%1 laajennustiedostot"
+
+msgctxt "PluginsPage|"
+msgid "Failed to install add-on"
+msgstr "Laajennuksen asennus epäonnistui"
+
+msgctxt "PluginsPage|"
+msgid "Warning!"
+msgstr "Varoitus!"
+
+msgctxt "PluginsPage|"
+msgid "Add-on requests dangerous permissions:"
+msgstr "Laajennus pyytää vaarallisia oikeuksia:"
+
+msgctxt "PluginsPage|"
+msgid "Add-on requests dangerous permission:"
+msgstr "Laajennus pyytää vaarallista oikeutta:"
+
+msgctxt "PluginsPage|"
+msgid "Please install add-ons from trusted sources only."
+msgstr "Asennathan laajennuksia vain luotettavista lähteistä."
+
+msgctxt "PluginsPage|"
+msgid "Would you like to continue the installation?"
+msgstr "Haluatko jatkaa asennusta?"
+
+msgctxt "PluginsPage|"
+msgid "The following required components are missing:"
+msgstr "Seuraavat vaadittavat komponentit puuttuvat:"
+
+msgctxt "PluginsPage|"
+msgid "%1 is required."
+msgstr "%1 vaaditaan."
+
+msgctxt "PluginsPage|"
+msgid "Would you like to install them?"
+msgstr "Haluatko asentaa ne?"
+
+msgctxt "PluginsPage|"
+msgid "Would you like to install it?"
+msgstr "Haluatko asentaa sen?"
+
+msgctxt "PluginsPage|"
+msgid "No updates found"
+msgstr "Ei päivityksiä"
+
+msgctxt "PluginsUpdateUiManager|"
+msgid "Failed to update add-on"
+msgstr "Laajennuksen päivittäminen epäonnistui"
+
+msgctxt "PluginsUpdateUiManager|"
+msgid "Warning!"
+msgstr "Varoitus!"
+
+msgctxt "PluginsUpdateUiManager|"
+msgid "New version of %1 add-on requests dangerous permissions:"
+msgstr "Laajennuksen %1 uusi versio pyytää vaarallisia oikeuksia:"
+
+msgctxt "PluginsUpdateUiManager|"
+msgid "New version of %1 add-on requests dangerous permission:"
+msgstr "Laajennuksen %1 uusi versio pyytää vaarallista oikeutta:"
+
+msgctxt "PluginsUpdateUiManager|"
+msgid "Please install add-ons from trusted sources only."
+msgstr "Asennathan laajennuksia vain luotettavista lähteistä."
+
+msgctxt "PluginsUpdateUiManager|"
+msgid "Would you like to continue the installation?"
+msgstr "Haluatko jatkaa asennusta?"
+
+msgctxt "PluginsUpdateUiManager|"
+msgid ""
+"New version of %1 add-on requires additional components:\n"
+"%2"
+msgstr ""
+"Laajennuksen %1 uusi versio vaatii lisäkomponentteja:\n"
+"%2"
+
+msgctxt "PluginsUpdateUiManager|"
+msgid "New version of %1 add-on requires %2."
+msgstr "Laajennuksen %1 uusi versio vaatii %2."
+
+msgctxt "PluginsUpdateUiManager|"
+msgid "Would you like to install them?"
+msgstr "Haluatko asentaa ne?"
+
+msgctxt "PluginsUpdateUiManager|"
+msgid "Would you like to install it?"
+msgstr "Haluatko asentaa sen?"
+
+msgctxt "PluginsViewItem|"
+msgid "Allow Automatic Updates"
+msgstr "Salli automaattiset päivitykset"
+
+msgctxt "PluginsViewItem|"
+msgid "Check for Updates"
+msgstr "Tarkista päivitykset"
+
+msgctxt "PluginsViewItem|"
+msgid "Remove"
+msgstr "Poista"
+
+msgctxt "PluginsViewItem|"
+msgid "Updating..."
+msgstr "Päivitetään…"
+
+msgctxt "PluginsViewItem|"
+msgid "Version: %1"
+msgstr "Versio: %1"
+
+msgctxt "PluginsViewItem|"
+msgid "OK to remove?"
+msgstr "Poistetaanko?"
+
+msgctxt "PreferredFileTypeCombobox|"
+msgid "Audio"
+msgstr "Ääni"
+
+msgctxt "PreferredFileTypeCombobox|"
+msgid "Video"
+msgstr "Video"
+
+msgctxt "PreferredVideoQualityCombobox|"
+msgid "Lowest"
+msgstr "Matalin"
+
+msgctxt "PreferredVideoQualityCombobox|"
+msgid "Highest"
+msgstr "Korkein"
+
+msgctxt "PrivacyDialog|"
+msgid "User agreement"
+msgstr "Käyttäjäsopimus"
+
+msgctxt "PrivacyDialog|"
+msgid ""
+"A bug report will be sent to the server and used to improve %1 performance. "
+"We do not collect your personal data and do not share data with third "
+"parties."
+msgstr ""
+"Virheraportti lähetetään palvelimelle ja sitä käytetään kehittämään %1:n "
+"suorituskykyä. Emme kerää henkilökohtaisia tietojasi, emmekä jaa tietoja "
+"kolmansien osapuolien kanssa."
+
+msgctxt "PrivacyDialog|"
+msgid "I agree (do not show it again)"
+msgstr "Hyväksyn (älä näytä uudelleen)"
+
+msgctxt "PrivacyDialog|"
+msgid "Send report"
+msgstr "Lähetä raportti"
+
+msgctxt "PrivacyDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt ""
+"QGuiApplication|Translate this string to the string 'LTR' in left-to-right "
+"languages or to 'RTL' in right-to-left languages (such as Hebrew and Arabic) "
+"to get proper UI layout."
+msgid "QT_LAYOUT_DIRECTION"
+msgstr "LTR"
+
+msgctxt "QObject|"
+msgid "Unexpected error"
+msgstr "Odottamaton virhe"
+
+msgctxt "QObject|"
+msgid "Service connection terminated."
+msgstr "Yhteys palveluun katkaistu."
+
+msgctxt "QObject|"
+msgid "App backend's server listen failed."
+msgstr "Ohjelman taustapalvelun yhteys epäonnistui."
+
+msgctxt "QObject|"
+msgid "Error"
+msgstr "Virhe"
+
+msgctxt "QObject|"
+msgid "Connection failure"
+msgstr "Yhteysvirhe"
+
+msgctxt "QObject|"
+msgid "App frontend's server listen failed."
+msgstr "Ohjelman käyttöliittymän yhteys epäonnistui."
+
+msgctxt "QObject|"
+msgid "QML load failure."
+msgstr "QML latausvirhe."
+
+msgctxt "QObject|"
+msgid "Failed to initialize app state manager."
+msgstr "Ohjelman tilan hallinnan latausvirhe."
+
+msgctxt "QObject|"
+msgid ""
+"\n"
+"Error: %1"
+msgstr ""
+"\n"
+"Virhe: %1"
+
+msgctxt "QObject|"
+msgid "Enter URL"
+msgstr "URL"
+
+msgctxt "QObject|"
+msgid "Sorry this device is not supported by %1."
+msgstr "%1 ei tue tätä laitetta, pahoittelumme."
+
+msgctxt "QObject|"
+msgid "%1 has failed to initialize. Please reinstall."
+msgstr "%1 ei voinut käynnistyä. Uudelleenasennus vaaditaan."
+
+msgctxt "QObject|"
+msgid "Reason: %1"
+msgstr "Syy: %1"
+
+msgctxt "QObject|"
+msgid "Contact Support"
+msgstr "Tuki"
+
+msgctxt "QObject|"
+msgid "Exit"
+msgstr "Poistu"
+
+msgctxt "QObject|"
+msgid "Show main window"
+msgstr "Näytä pääikkuna"
+
+msgctxt "QObject|"
+msgid "About %1"
+msgstr "Tietoja %1:sta"
+
+msgctxt "QObject|"
+msgid "Quit"
+msgstr "Lopeta"
+
+msgctxt "QObject|"
+msgid "%1 B"
+msgstr "%1 B"
+
+msgctxt "QObject|"
+msgid "%1 KB"
+msgstr "%1 KB"
+
+msgctxt "QObject|"
+msgid "%1 MB"
+msgstr "%1 MB"
+
+msgctxt "QObject|"
+msgid "%1 GB"
+msgstr "%1 GB"
+
+msgctxt "QObject|"
+msgid "%1 TB"
+msgstr "%1 TB"
+
+msgctxt "QObject|"
+msgid "%1 K"
+msgstr "%1 K"
+
+msgctxt "QObject|"
+msgid "%1 M"
+msgstr "%1 M"
+
+msgctxt "QObject|"
+msgid "%1 G"
+msgstr "%1 G"
+
+msgctxt "QObject|"
+msgid "%1 T"
+msgstr "%1 T"
+
+msgctxt "QObject|"
+msgid "%1 B/s"
+msgstr "%1 B/s"
+
+msgctxt "QObject|"
+msgid "%1 KB/s"
+msgstr "%1 KB/s"
+
+msgctxt "QObject|"
+msgid "%1 MB/s"
+msgstr "%1 MB/s"
+
+msgctxt "QObject|"
+msgid "%1 GB/s"
+msgstr "%1 GB/s"
+
+msgctxt "QObject|"
+msgid "%1 TB/s"
+msgstr "%1 TB/s"
+
+msgctxt "QObject|"
+msgid "%1 K/s"
+msgstr "%1 K/s"
+
+msgctxt "QObject|"
+msgid "%1 M/s"
+msgstr "%1 M/s"
+
+msgctxt "QObject|"
+msgid "%1 G/s"
+msgstr "%1 G/s"
+
+msgctxt "QObject|"
+msgid "%1 T/s"
+msgstr "%1 T/s"
+
+msgctxt "QObject|"
+msgid "Download complete"
+msgstr "Lataus valmis"
+
+msgctxt "QObject|"
+msgid "Downloads complete"
+msgstr "Lataukset valmiita"
+
+msgctxt "QObject|"
+msgid "Download failed"
+msgstr "Lataus epäonnistui"
+
+msgctxt "QObject|"
+msgid "Downloads failed"
+msgstr "Lataukset epäonnistuivat"
+
+msgctxt "QObject|"
+msgid "Download added"
+msgstr "Lataus lisätty"
+
+msgctxt "QObject|"
+msgid "Unknown error"
+msgstr "Määrittelemätön virhe"
+
+msgctxt "QObject|"
+msgid "File read error"
+msgstr "Tiedoston lukuvirhe"
+
+msgctxt "QObject|"
+msgid "Failed to read from file"
+msgstr "Tiedoston lukeminen epäonnistui"
+
+msgctxt "QObject|"
+msgid "File write error"
+msgstr "Tiedoston kirjoitusvirhe"
+
+msgctxt "QObject|"
+msgid "Failed to write to file"
+msgstr "Tiedostoon kirjoittaminen epäonnistui"
+
+msgctxt "QObject|"
+msgid "File open error"
+msgstr "Tiedoston avausvirhe"
+
+msgctxt "QObject|"
+msgid "Failed to open file"
+msgstr "Tiedostoa ei voitu avata"
+
+msgctxt "QObject|"
+msgid "Access denied"
+msgstr "Pääsy evätty"
+
+msgctxt "QObject|"
+msgid "Access to file is denied"
+msgstr "Pääsy tiedostoon evätty"
+
+msgctxt "QObject|"
+msgid "File error"
+msgstr "Tiedostovirhe"
+
+msgctxt "QObject|"
+msgid "Unknown file I/O error"
+msgstr "Määrittelemätön tiedostovirhe"
+
+msgctxt "QObject|"
+msgid "HTTP Error %1"
+msgstr "HTTP-virhe %1"
+
+msgctxt "QObject|"
+msgid "Bad Request"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Unauthorized"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Payment Required"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Forbidden"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Not Found"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Method Not Allowed"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Not Acceptable"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Proxy Authentication Required"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Request Timeout"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Conflict"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Gone"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Length Required"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Precondition Failed"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Request Entity Too Large"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Request-URI Too Long"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Unsupported Media Type"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Requested Range Not Satisfiable"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Expectation Failed"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "I'm a teapot"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Authentication Timeout"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Method Failure / Enhance Your Calm"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Unprocessable Entity"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Locked"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Failed Dependency / Method Failure"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Unordered Collection"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Upgrade Required"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Precondition Required"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Too Many Requests"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Request Header Fields Too Large"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Login Timeout"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "No Response"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Retry With"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Blocked by Windows Parental Controls"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Unavailable For Legal Reasons"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Request Header Too Large"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Cert Error"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "No Cert"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "HTTP to HTTPS"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Token expired/invalid"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Client Closed Request"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Internal Server Error"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Not Implemented"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Bad Gateway"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Service Unavailable"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Gateway Timeout"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "HTTP Version Not Supported"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Variant Also Negotiates"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Insufficient Storage"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Loop Detected"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Bandwidth Limit Exceeded"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Not Extended"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Network Authentication Required"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Network read timeout error"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Network connect timeout error"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Unsupported"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Invalid parameter"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Unsupported format"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Not found"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Incompatible version"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Host not found"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Operation canceled"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Connection closed"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Timed out"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "SSL handshake failed"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Connection refused"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Network error"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Operation not permitted"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "No resume support"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Resource changed"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Resource changed on server"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Fast resume failure"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Can't process page"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Error processing page content"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Unwanted behavior"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Unwanted behavior detected"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Unsupported URL"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Untitled"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Failed to remove current version"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "hdiutil error %1"
+msgstr "hdiutil-virhe %1"
+
+msgctxt "QObject|"
+msgid "Mount point does not exist"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Signature check failure."
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Download with %1"
+msgstr "Lataa %1:lla"
+
+msgctxt "QObject|"
+msgid "Download all with %1"
+msgstr "Lataa kaikki %1:lla"
+
+msgctxt "QObject|"
+msgid "Download selected with %1"
+msgstr "Lataa valinta %1:lla"
+
+msgctxt "QObject|"
+msgid "Download video with %1"
+msgstr "Lataa video %1:lla"
+
+msgctxt "QObject|"
+msgid "Video"
+msgstr "Video"
+
+msgctxt "QObject|"
+msgid "Music"
+msgstr "Musiikki"
+
+msgctxt "QObject|"
+msgid "There is not enough disk space."
+msgstr "Ei riittävästi levytilaa."
+
+msgctxt "QObject|"
+msgid ""
+"The list of downloads is damaged.\n"
+"%1 has failed to restore it from backup.\n"
+"Please close all your web browsers and try again."
+msgstr ""
+"Latauslista on vioittunut.\n"
+"%1 ei voinut palauttaa sitä varmuuskopiosta.\n"
+"Sulje kaikki verkkoselaimet ja yritä uudelleen."
+
+msgctxt "QObject|"
+msgid "Fatal error: failed to load the database."
+msgstr "Kriittinen virhe: tietokannan lataus epäonnistui."
+
+msgctxt "QObject|"
+msgid ""
+"Would you like to erase it (this will clear your downloads list and all %1 "
+"data)?"
+msgstr "Haluatko nollata sen? (Tämä poistaa latauslistasi ja kaikki tietosi.)"
+
+msgctxt "QObject|"
+msgid "Failed."
+msgstr "Epäonnistui."
+
+msgctxt "QObject|"
+msgid "Missing %path% parameter."
+msgstr "Puuttuva %path%-parametri."
+
+msgctxt "QObject|"
+msgid "Update URL"
+msgstr "Päivitä URL"
+
+msgctxt "QObject|"
+msgid "Documents"
+msgstr "Tiedostot"
+
+msgctxt "QObject|"
+msgid "Pictures"
+msgstr "Kuvat"
+
+msgctxt "QObject|"
+msgid "Videos"
+msgstr "Videot"
+
+msgctxt "QObject|"
+msgid "Miscellaneous"
+msgstr "Sekalaiset"
+
+msgctxt "QObject|"
+msgid "upload paused"
+msgstr "lähetys tauolla"
+
+msgctxt "QObject|"
+msgid "PAUSE ALL"
+msgstr "TAUOTA KAIKKI"
+
+msgctxt "QObject|"
+msgid "Downloading..."
+msgstr "Ladataan…"
+
+msgctxt "QObject|"
+msgid "DISABLE SNAIL MODE"
+msgstr "POISTA ETANATILA KÄYTÖSTÄ"
+
+msgctxt "QObject|"
+msgid "SNAIL MODE"
+msgstr "ETANATILA"
+
+msgctxt "QObject|"
+msgid "YouTube downloads are not available"
+msgstr "YouTubesta lataaminen ei ole saatavilla"
+
+msgctxt "QObject|"
+msgid "Files were modified"
+msgstr "Tiedostoja on muokattu"
+
+# Needs more context.
+msgctxt "QObject|"
+msgid "%1 of unknown at %2"
+msgstr ""
+
+# Needs more context.
+msgctxt "QObject|"
+msgid "%1 of %2 at %3"
+msgstr ""
+
+# Needs more context.
+msgctxt "QObject|"
+msgid "%1 %2 or higher"
+msgstr ""
+
+msgctxt "QObject|"
+msgid "Launch Python code"
+msgstr "Käynnistä Python-koodi"
+
+msgctxt "QObject|"
+msgid "Allows to execute arbitrary code."
+msgstr "Sallii koodin suorittamisen vapaasti."
+
+msgctxt "QObject|"
+msgid "Installing..."
+msgstr "Asennetaan…"
+
+msgctxt "QObject|"
+msgid "Uninstalling..."
+msgstr "Poistetaan…"
+
+msgctxt "QObject|"
+msgid "Missing components"
+msgstr "Puuttuvat komponentit"
+
+msgctxt "QObject|"
+msgid "%1 are required"
+msgstr "%1 vaaditaan"
+
+msgctxt "QObject|"
+msgid "%1 is required"
+msgstr "%1 vaaditaan"
+
+msgctxt "QObject|"
+msgid "Failed to load"
+msgstr "Latausvirhe"
+
+msgctxt "QObject|"
+msgid "Playlist"
+msgstr "Soittolista"
+
+msgctxt "QuaGzipFile|"
+msgid "QIODevice::Append is not supported for GZIP"
+msgstr ""
+
+msgctxt "QuaGzipFile|"
+msgid "Opening gzip for both reading and writing is not supported"
+msgstr ""
+
+msgctxt "QuaGzipFile|"
+msgid "You can open a gzip either for reading or for writing. Which is it?"
+msgstr ""
+
+msgctxt "QuaGzipFile|"
+msgid "Could not gzopen() file"
+msgstr ""
+
+msgctxt "QuaZIODevice|"
+msgid "QIODevice::Append is not supported for QuaZIODevice"
+msgstr ""
+
+msgctxt "QuaZIODevice|"
+msgid "QIODevice::ReadWrite is not supported for QuaZIODevice"
+msgstr ""
+
+msgctxt "QuaZipFile|"
+msgid "ZIP/UNZIP API error %1"
+msgstr ""
+
+msgctxt "QuitConfirmationDialog|"
+msgid "Are you sure you want to quit?"
+msgstr "Haluatko varmasti lopettaa?"
+
+msgctxt "QuitConfirmationDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "QuitConfirmationDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "RemoteControlSettings|"
+msgid "Remote Access"
+msgstr "Etähallinta"
+
+msgctxt "RemoteControlSettings|"
+msgid "(beta)"
+msgstr "(beta)"
+
+msgctxt "RemoteControlSettings|"
+msgid "Allow remote access to %1 running on this device"
+msgstr "Salli etäyhteys %1:iin tällä laitteella"
+
+msgctxt "RemoteControlSettings|"
+msgid "Password"
+msgstr "Salasana"
+
+msgctxt "RemoteControlSettings|"
+msgid "Status"
+msgstr "Tila"
+
+msgctxt "RemoteControlSettings|"
+msgid "Don't use network proxy"
+msgstr "Älä käytä välityspalvelinta"
+
+msgctxt "RemoteControlSettings|"
+msgid "Remote control settings"
+msgstr "Etähallinnan asetukset"
+
+msgctxt "RemoteResourceChangedDialog|"
+msgid "Remote resource changed"
+msgstr "Etäresurssi muuttui"
+
+msgctxt "RemoteResourceChangedDialog|"
+msgid "Always re-download"
+msgstr "Lataa aina uudelleen"
+
+msgctxt "RemoteResourceChangedDialog|"
+msgid "Re-download"
+msgstr "Lataa uudelleen"
+
+msgctxt "RemoteResourceChangedDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "RenameDownloadFileDialog|"
+msgid "Rename file"
+msgstr "Nimeä tiedosto uudelleen"
+
+msgctxt "RenameDownloadFileDialog|"
+msgid "Enter new name"
+msgstr "Uusi nimi"
+
+msgctxt "RenameDownloadFileDialog|"
+msgid "A file with that name already exists."
+msgstr "Tiedosto tällä nimellä on jo olemassa."
+
+msgctxt "RenameDownloadFileDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "RenameDownloadFileDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "RenameDownloadFilePage|"
+msgid "Rename file"
+msgstr "Nimeä tiedosto uudelleen"
+
+msgctxt "RenameDownloadFilePage|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "RenameDownloadFilePage|"
+msgid "Enter new name"
+msgstr "Uusi nimi"
+
+msgctxt "RenameDownloadFilePage|"
+msgid "A file with that name already exists."
+msgstr "Tiedosto tällä nimellä on jo olemassa."
+
+msgctxt "ReportSentDialog|"
+msgid "Report problem"
+msgstr "Ilmoita ongelmasta"
+
+msgctxt "ReportSentDialog|"
+msgid "Sorry, the report hasn't been sent, an error occurred: %1"
+msgstr "Raporttia ei voitu lähettää, virhe: %1"
+
+msgctxt "ReportSentDialog|"
+msgid "The report has been sent. Thank you for your cooperation!"
+msgstr "Raportti lähetetty. Kiitos yhteistyöstä!"
+
+msgctxt "ReportSentDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "RestartRequiredLabel|"
+msgid "<a href='#'>Restart is required</a>"
+msgstr "<a href='#'>Uudelleenkäynnistys vaaditaan</a>"
+
+msgctxt "SaveTo|"
+msgid "Save to"
+msgstr "Tallenna nimellä"
+
+msgctxt "SaveTo|"
+msgid "Open"
+msgstr "Avaa"
+
+msgctxt "SaveTo|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "Scheduler|"
+msgid "Sun"
+msgstr "su"
+
+msgctxt "Scheduler|"
+msgid "Mon"
+msgstr "ma"
+
+msgctxt "Scheduler|"
+msgid "Tue"
+msgstr "ti"
+
+msgctxt "Scheduler|"
+msgid "Wed"
+msgstr "ke"
+
+msgctxt "Scheduler|"
+msgid "Thu"
+msgstr "to"
+
+msgctxt "Scheduler|"
+msgid "Fri"
+msgstr "pe"
+
+msgctxt "Scheduler|"
+msgid "Sat"
+msgstr "la"
+
+msgctxt "Scheduler|"
+msgid "From:"
+msgstr "Mistä:"
+
+msgctxt "Scheduler|"
+msgid "Everyday"
+msgstr "Joka päivä"
+
+msgctxt "Scheduler|"
+msgid "To:"
+msgstr "Mihin:"
+
+msgctxt "SchedulerButton|"
+msgid "Scheduler"
+msgstr "Aikataulutus"
+
+msgctxt "SchedulerCheckbox|"
+msgid "Scheduler"
+msgstr "Aikataulutus"
+
+msgctxt "SchedulerDialog|"
+msgid "Scheduler"
+msgstr "Aikataulutus"
+
+msgctxt "SchedulerDialog|"
+msgid "Start and pause downloads at specified time"
+msgstr "Aloita ja tauota lataukset tiettyinä aikoina"
+
+msgctxt "SchedulerDialog|"
+msgid "Enable Scheduler"
+msgstr "Ota aikataulutus käyttöön"
+
+msgctxt "SchedulerDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "SchedulerDialog|"
+msgid "Apply"
+msgstr "Käytä"
+
+msgctxt "SchedulerDialog|"
+msgid "All the day"
+msgstr "Koko päivän"
+
+msgctxt "SchedulerDialog|"
+msgid "Everyday"
+msgstr "Joka päivä"
+
+msgctxt "SchedulerDialog|"
+msgid "Close"
+msgstr "Sulje"
+
+msgctxt "SchedulerDialog|"
+msgid "Sun"
+msgstr "su"
+
+msgctxt "SchedulerDialog|"
+msgid "Mon"
+msgstr "ma"
+
+msgctxt "SchedulerDialog|"
+msgid "Tue"
+msgstr "ti"
+
+msgctxt "SchedulerDialog|"
+msgid "Wed"
+msgstr "ke"
+
+msgctxt "SchedulerDialog|"
+msgid "Thu"
+msgstr "to"
+
+msgctxt "SchedulerDialog|"
+msgid "Fri"
+msgstr "pe"
+
+msgctxt "SchedulerDialog|"
+msgid "Sat"
+msgstr "la"
+
+msgctxt "SchedulerTools|"
+msgid "Set days of the week to enable Scheduler"
+msgstr "Päivät, joina aikataulutus on käytössä"
+
+msgctxt "SearchField|"
+msgid "Search"
+msgstr "Hae"
+
+msgctxt "SearchToolbar|"
+msgid "Search"
+msgstr "Hae"
+
+msgctxt "SelectModeTopBar|"
+msgid "Selected: %1"
+msgstr "Valittu: %1"
+
+msgctxt "SelectSortFieldDialog|"
+msgid "Sort"
+msgstr "Järjestys"
+
+msgctxt "SelectSortFieldDialog|"
+msgid "By date"
+msgstr "Päivämäärä"
+
+msgctxt "SelectSortFieldDialog|"
+msgid "By name"
+msgstr "Nimi"
+
+msgctxt "SelectSortFieldDialog|"
+msgid "By size"
+msgstr "Koko"
+
+msgctxt "SelectSortFieldDialog|"
+msgid "Ascending"
+msgstr "Nouseva"
+
+msgctxt "SelectSortFieldDialog|"
+msgid "Descending"
+msgstr "Laskeva"
+
+msgctxt "SettingsPage|"
+msgid "Invalid settings"
+msgstr "Virheelliset asetukset"
+
+msgctxt "SettingsPage|"
+msgid ". Close anyway?"
+msgstr ". Sulje silti?"
+
+msgctxt "SettingsPage|"
+msgid "Preferences"
+msgstr "Asetukset"
+
+msgctxt "SettingsPage|"
+msgid "General"
+msgstr "Yleinen"
+
+msgctxt "SettingsPage|"
+msgid "Browser Integration"
+msgstr "Selainintegraatio"
+
+msgctxt "SettingsPage|"
+msgid "Network"
+msgstr "Verkko"
+
+msgctxt "SettingsPage|"
+msgid "Traffic Limits"
+msgstr "Verkon käyttö"
+
+msgctxt "SettingsPage|"
+msgid "Antivirus"
+msgstr "Virustorjunta"
+
+msgctxt "SettingsPage|"
+msgid "Remote Access"
+msgstr "Etähallinta"
+
+msgctxt "SettingsPage|"
+msgid "Advanced"
+msgstr "Lisäasetukset"
+
+msgctxt "SettingsPage|"
+msgid "Troubleshooting"
+msgstr "Vianmääritys"
+
+msgctxt "SettingsPage|"
+msgid "Settings"
+msgstr "Asetukset"
+
+msgctxt "SettingsPage|"
+msgid "Downloads settings"
+msgstr "Latausasetukset"
+
+msgctxt "SettingsPage|"
+msgid "Network settings"
+msgstr "Verkon asetukset"
+
+msgctxt "SettingsPage|"
+msgid "Traffic limits"
+msgstr "Verkon käyttö"
+
+msgctxt "SettingsPage|"
+msgid "Sounds settings"
+msgstr "Ääniasetukset"
+
+msgctxt "SettingsPage|"
+msgid "Remote control settings"
+msgstr "Etähallinnan asetukset"
+
+msgctxt "SettingsPage|"
+msgid "Advanced settings"
+msgstr "Lisäasetukset"
+
+msgctxt "SettingsPage|"
+msgid "Reset settings"
+msgstr "Nollaa asetukset"
+
+msgctxt "SettingsPage|"
+msgid "Default settings"
+msgstr "Oletusasetukset"
+
+msgctxt "SettingsPage|"
+msgid "Restore default settings?"
+msgstr "Palauta oletusasetukset?"
+
+msgctxt "ShutdownBanner|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "ShutdownBanner|"
+msgid "Computer will be put to sleep after all downloads are completed."
+msgstr "Tietokone asetetaan lepotilaan kaikkien latausten valmistuttua."
+
+msgctxt "ShutdownBanner|"
+msgid "Computer will be hibernate after all downloads are completed."
+msgstr "Tietokone asetetaan horrostilaan kaikkien latausten valmistuttua."
+
+msgctxt "ShutdownBanner|"
+msgid "Computer will be shutdown after all downloads are completed."
+msgstr "Tietokone sammutetaan kaikkien latausten valmistuttua."
+
+msgctxt "ShutdownDialog|"
+msgid "Confirm"
+msgstr "OK"
+
+msgctxt "ShutdownDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "ShutdownDialog|"
+msgid "OK (%1)"
+msgstr "OK (%1)"
+
+msgctxt "ShutdownDialog|"
+msgid "Attention! Your computer will be put to Sleep mode."
+msgstr "Huomio! Tietokone asetetaan lepotilaan."
+
+msgctxt "ShutdownDialog|"
+msgid "Attention! Your computer will be hibernated."
+msgstr "Huomio! Tietokone asetetaan horrostilaan."
+
+msgctxt "ShutdownDialog|"
+msgid "Attention! Your computer will be shut down."
+msgstr "Huomio! Tietokone sammutetaan."
+
+msgctxt "SoundsSettings|"
+msgid "Sounds settings"
+msgstr "Ääniasetukset"
+
+msgctxt "SoundsSettings|"
+msgid "Use sounds"
+msgstr "Käytä ääniä"
+
+msgctxt "SoundsSettings|"
+msgid "Downloads added"
+msgstr "Lataus lisättiin"
+
+msgctxt "SoundsSettings|"
+msgid "Downloads completed"
+msgstr "Lataus valmistui"
+
+msgctxt "SoundsSettings|"
+msgid "Downloads failed"
+msgstr "Lataus epäonnistui"
+
+msgctxt "SoundsSettings|"
+msgid "No active downloads"
+msgstr "Ei aktiivisia latauksia"
+
+msgctxt "SslDialog|"
+msgid "Warning: potential security risk ahead"
+msgstr "Varoitus: mahdollinen tietoturvauhka"
+
+msgctxt "SslDialog|"
+msgid "SSL Certificate is not valid."
+msgstr "SSL-sertifikaatti on virheellinen."
+
+msgctxt "SslDialog|"
+msgid "Certificate fingerprints"
+msgstr "Sertifikaatin sormenjäljet"
+
+msgctxt "SslDialog|"
+msgid "SHA-256:"
+msgstr "SHA-256:"
+
+msgctxt "SslDialog|"
+msgid "SHA1:"
+msgstr "SHA1:"
+
+msgctxt "SslDialog|"
+msgid "Accept the risk and download"
+msgstr "Hyväksy riski ja lataa"
+
+msgctxt "SslDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "SslDialog|"
+msgid "Security risk"
+msgstr "Tietoturvariski"
+
+msgctxt "SslDialog|"
+msgid "Continue"
+msgstr "Jatka"
+
+msgctxt "StatusItem|"
+msgid "Checking files"
+msgstr "Tarkistetaan tiedostoja"
+
+msgctxt "StatusItem|"
+msgid "Merging media streams"
+msgstr "Yhdistetään mediastriimejä"
+
+msgctxt "StatusItem|"
+msgid "Queued"
+msgstr "Jonossa"
+
+msgctxt "StatusItem|"
+msgid "Requesting info"
+msgstr "Pyydetään tietoja"
+
+msgctxt "StatusItem|"
+msgid "Unknown file size"
+msgstr "Tiedostokoko ei tiedossa"
+
+msgctxt "StatusItem|"
+msgid "Paused"
+msgstr "Tauolla"
+
+msgctxt "StatusItem|"
+msgid "Completed"
+msgstr "Valmis"
+
+msgctxt "StopDownloadDialog|"
+msgid "Pause download"
+msgstr "Latauksen tauotus"
+
+msgctxt "StopDownloadDialog|"
+msgid "The download(s) below can't be resumed after pausing."
+msgstr "Seuraavia latauksia ei voida jatkaa tauotuksen jälkeen."
+
+msgctxt "StopDownloadDialog|"
+msgid "Pause"
+msgstr "Tauota"
+
+msgctxt "StopDownloadDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "StopDownloadDialog|"
+msgid "This download can't be resumed after pausing"
+msgstr "Tätä latausta ei voi jatkaa tauotuksen jälkeen"
+
+msgctxt "StopDownloadDialog|"
+msgid "The download(s) below can't be resumed after pausing"
+msgstr "Seuraavia latauksia ei voida jatkaa tauotuksen jälkeen"
+
+msgctxt "Subtitles|"
+msgid "Download subtitles"
+msgstr "Lataa tekstitykset"
+
+msgctxt "Subtitles|"
+msgid "Edit list"
+msgstr "Muokkaa listaa"
+
+msgctxt "TagMenu|"
+msgid "Edit"
+msgstr "Muokkaa"
+
+msgctxt "TagMenu|"
+msgid "Remove"
+msgstr "Poista"
+
+msgctxt "TagPalette|"
+msgid "Customize color"
+msgstr "Muokkaa väriä"
+
+msgctxt "ThemeComboBox|"
+msgid "System"
+msgstr "Järjestelmä"
+
+msgctxt "ThemeComboBox|"
+msgid "Light"
+msgstr "Vaalea"
+
+msgctxt "ThemeComboBox|"
+msgid "Dark"
+msgstr "Tumma"
+
+msgctxt "Toast|"
+msgid "Please grant camera permission to use the QR scanner"
+msgstr "Kameran lupa tarvitaan QR-skannaukseen"
+
+msgctxt "TrafficLimitsSettings|"
+msgid "Traffic Limits"
+msgstr "Verkon käyttö"
+
+msgctxt "TrafficLimitsSettings|"
+msgid "Low"
+msgstr "Matala"
+
+msgctxt "TrafficLimitsSettings|"
+msgid "Medium"
+msgstr "Kohtalainen"
+
+msgctxt "TrafficLimitsSettings|"
+msgid "High"
+msgstr "Korkea"
+
+msgctxt "TrafficLimitsSettings|"
+msgid "Download speed"
+msgstr "Latausnopeus"
+
+msgctxt "TrafficLimitsSettings|"
+msgid "Upload speed"
+msgstr "Lähetysnopeus"
+
+msgctxt "TrafficLimitsSettings|"
+msgid "Maximum number of connections"
+msgstr "Yhteyksien enimmäismäärä"
+
+msgctxt "TrafficLimitsSettings|"
+msgid "Maximum number of connections per server"
+msgstr "Yhteyksien enimmäismäärä palvelinta kohden"
+
+msgctxt "TrafficLimitsSettings|"
+msgid "Maximum number of simultaneous downloads"
+msgstr "Samanaikaisten latauksien enimmäismäärä"
+
+msgctxt "TrafficLimitsSettings|"
+msgid "Maximum number of additional querying info downloads:"
+msgstr "Ylimääräisten tietoa hakevien latausten enimmäismäärä:"
+
+msgctxt "TrafficLimitsSettings|"
+msgid "Invalid traffic limits settings"
+msgstr "Virheelliset verkon käytön asetukset"
+
+msgctxt "TrafficLimitsSettings|"
+msgid "Traffic limits"
+msgstr "Verkon käyttö"
+
+msgctxt "TroubleshootingSettings|"
+msgid "Troubleshooting"
+msgstr "Vianmääritys"
+
+msgctxt "TroubleshootingSettings|"
+msgid "Archive logs..."
+msgstr "Arkistoi lokit…"
+
+msgctxt "TroubleshootingSettings|"
+msgid "Zip files"
+msgstr "ZIP-tiedostot"
+
+msgctxt "TroubleshootingSettings|"
+msgid "Failed"
+msgstr "Epäonnistui"
+
+msgctxt "TroubleshootingSettings|"
+msgid "Archive service data..."
+msgstr "Arkistoi palvelutiedot…"
+
+msgctxt "TroubleshootingSettings|"
+msgid "Hide"
+msgstr "Piilota"
+
+msgctxt "TumComboBox|"
+msgid "Unlimited"
+msgstr "Rajoittamaton"
+
+msgctxt "TumComboBox|"
+msgid "KB/s"
+msgstr "KB/s"
+
+msgctxt "TumComboBox|"
+msgid "unlimited"
+msgstr "rajoittamaton"
+
+msgctxt "TumComboBox|"
+msgid "Download: %1, Upload: %2"
+msgstr "Lataus: %1, Lähetys: %2"
+
+msgctxt "TumComboBox|"
+msgid "High"
+msgstr "Korkea"
+
+msgctxt "TumComboBox|"
+msgid "Medium"
+msgstr "Kohtalainen"
+
+msgctxt "TumComboBox|"
+msgid "Low"
+msgstr "Matala"
+
+msgctxt "TumMaxURatioComboBox|"
+msgid "Unlimited"
+msgstr "Rajoittamaton"
+
+msgctxt "TumMaxURatioComboBox|"
+msgid "Custom..."
+msgstr "Muu…"
+
+msgctxt "TumMaxURatioComboBox|"
+msgid "Please enter numbers only"
+msgstr "Syötä vain numeroita"
+
+msgctxt "TumModeBlock|"
+msgid "Download speed"
+msgstr "Latausnopeus"
+
+msgctxt "TumModeBlock|"
+msgid "Unlimited"
+msgstr "Rajoittamaton"
+
+msgctxt "TumModeBlock|"
+msgid "Max. number of simultaneous downloads"
+msgstr "Samanaikaisten latauksien enimmäismäärä"
+
+msgctxt "TumModeBlock|"
+msgid "Snail mode"
+msgstr "Etanatila"
+
+msgctxt "TumModeBlock|"
+msgid "Frees bandwidth without stopping downloads."
+msgstr "Vapauttaa kaistanleveyttä ilman latausten pysäyttämistä."
+
+msgctxt "TumModeDialog|"
+msgid "Change traffic limits"
+msgstr "Muuta verkon käyttöä"
+
+msgctxt "TumSettingTextField|"
+msgid "Can't be greater than %1"
+msgstr "Ei voi olla suurempi kuin %1"
+
+msgctxt "TuneAndAddDownloadDialog|"
+msgid "New download"
+msgstr "Uusi lataus"
+
+msgctxt "TuneAndAddDownloadPage|"
+msgid "New file"
+msgstr "Uusi tiedosto"
+
+msgctxt "TuneAndAddDownloadPage|"
+msgid "Download"
+msgstr "Lataa"
+
+msgctxt "TuneAndAddDownloadPage|"
+msgid "Save to"
+msgstr "Tallenna nimellä"
+
+msgctxt "TuneAndAddDownloadPage|"
+msgid "File name"
+msgstr "Tiedostonimi"
+
+msgctxt "TuneAndAddDownloadPage|"
+msgid "No write access to the selected directory"
+msgstr "Ei kirjoitusoikeutta valittuun hakemistoon"
+
+msgctxt "TuneAndAddDownloadPage|"
+msgid "Size: %1 (Disk space: %2)"
+msgstr "Koko: %1 (Levytila: %2)"
+
+msgctxt "TuneAndAddDownloadPage|"
+msgid "Size: %1"
+msgstr "Koko: %1"
+
+msgctxt "UpdateDialog|"
+msgid "Checking for updates..."
+msgstr "Tarkistetaan päivityksiä…"
+
+msgctxt "UpdateDialog|"
+msgid "Error:"
+msgstr "Virhe:"
+
+msgctxt "UpdateDialog|"
+msgid "Retry"
+msgstr "Yritä uudelleen"
+
+msgctxt "UpdateDialog|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "UpdateDialog|"
+msgid "New version is available"
+msgstr "Uusi versio saatavilla"
+
+msgctxt "UpdateDialog|"
+msgid "What's new in %1"
+msgstr "Uutta %1"
+
+msgctxt "UpdateDialog|"
+msgid "Update"
+msgstr "Päivitä"
+
+msgctxt "UpdateDialog|"
+msgid "%1 is up to date"
+msgstr "%1 on ajan tasalla"
+
+msgctxt "UpdateDialog|"
+msgid "OK"
+msgstr "OK"
+
+msgctxt "UpdateDialog|"
+msgid "Downloading update"
+msgstr "Ladataan päivitystä"
+
+msgctxt "UpdateDialog|"
+msgid "Error downloading update:"
+msgstr "Virhe ladattaessa päivitystä:"
+
+msgctxt "UpdateDialog|"
+msgid "Checking..."
+msgstr "Tarkistetaan…"
+
+msgctxt "UpdateDialog|"
+msgid "Update downloaded"
+msgstr "Päivitys ladattu"
+
+msgctxt "UpdateDialog|"
+msgid "Install update"
+msgstr "Asenna päivitys"
+
+msgctxt "UpdateDialog|"
+msgid "Installing updates"
+msgstr "Asennetaan päivitystä"
+
+msgctxt "UpdateDialog|"
+msgid "Error occurred during installation:"
+msgstr "Virhe asennettaessa:"
+
+msgctxt "UpdateDialog|"
+msgid "Relaunch %1 to update"
+msgstr "Käynnistä %1 uudelleen päivittääksesi"
+
+msgctxt "UpdateDialog|"
+msgid "Relaunch"
+msgstr "Käynnistä uudelleen"
+
+msgctxt "UpdateDialog|"
+msgid "Later"
+msgstr "Myöhemmin"
+
+msgctxt "UpdateDialog|"
+msgid "Check for updates"
+msgstr "Tarkista päivitykset"
+
+msgctxt "VideoQuality|"
+msgid "Quality:"
+msgstr "Laatu:"
+
+msgctxt "VoteBlock|"
+msgid "Enjoy %1?"
+msgstr "Pidätkö %1:sta?"
+
+msgctxt "VoteBlock|"
+msgid "Not, really"
+msgstr "Enpä juuri"
+
+msgctxt "VoteBlock|"
+msgid "Yes!"
+msgstr "Joo!"
+
+msgctxt "VoteBlock|"
+msgid "Thanks a lot! Please rate on Google Play."
+msgstr "Kiitos paljon! Jätä meille arvostelu Google Playssa."
+
+msgctxt "VoteBlock|"
+msgid "Later"
+msgstr "Myöhemmin"
+
+msgctxt "VoteBlock|"
+msgid "No, thanks"
+msgstr "Ei kiitos"
+
+msgctxt "VoteBlock|"
+msgid "OK, sure!"
+msgstr "Mikä ettei"
+
+msgctxt "VoteBlock|"
+msgid "Let's make it better together! Give us your feedback."
+msgstr "Tehdään tästä parempi yhdessä! Anna meille palautetta."
+
+msgctxt "WaitingPage|"
+msgid "Loading"
+msgstr "Ladataan"
+
+msgctxt "WaitingPage|"
+msgid "Connection to %1"
+msgstr "Yhteys kohteeseen %1"
+
+msgctxt "WaitingPage|"
+msgid "Error: %1"
+msgstr "Virhe: %1"
+
+msgctxt "WaitingPage|"
+msgid "Retry"
+msgstr "Yritä uudelleen"
+
+msgctxt "WaitingPage|"
+msgid "Cancel"
+msgstr "Peru"
+
+msgctxt "WaitingPage|"
+msgid "Abort"
+msgstr "Keskeytä"
+
+msgctxt "WhatsNewDialog|"
+msgid "New version is available"
+msgstr "Uusi versio on saatavilla"
+
+msgctxt "WhatsNewDialog|"
+msgid "What's new in %1"
+msgstr "Uutta %1"
+
+msgctxt "WhatsNewDialog|"
+msgid "Update"
+msgstr "Päivitä"
+
+msgctxt "main|"
+msgid "Sorry, the report hasn't been sent, an error occurred: %1"
+msgstr "Raporttia ei voitu lähettää, virhe: %1"
+
+msgctxt "main|"
+msgid "The report has been sent. Thank you for your cooperation!"
+msgstr "Raportti lähetetty. Kiitos yhteistyöstä!"
+
+msgctxt "main|"
+msgid "Remote connection to %1"
+msgstr "Etäyhteys kohteeseen %1"


### PR DESCRIPTION
Translated everything but HTTP error messages and some other technical error messages. The only strings that need more context to translate are:

```
msgctxt "QObject|"
msgid "%1 of unknown at %2"
msgstr ""

msgctxt "QObject|"
msgid "%1 of %2 at %3"
msgstr ""

msgctxt "QObject|"
msgid "%1 %2 or higher"
msgstr ""
```