### PR TITLE
Corrections for Ukrainian and Russian languages, attempt № 2

### DIFF
--- a/main/fdm_ru.po
+++ b/main/fdm_ru.po
@@ -1010,7 +1010,7 @@ msgid ""
 "Both %1 and QR code are located inside of Preferences page of %2 you're "
 "going to connect to."
 msgstr ""
-"%1 и QR-код находятся на странице настроек %2, к которому вы собираетесь "
+"%1 и QR-код находятся на странице Настроек %2, к которой вы собираетесь "
 "подключиться."
 
 msgctxt "ConnectToRemoteAppDialog|"

--- a/main/fdm_uk.po
+++ b/main/fdm_uk.po
@@ -1007,7 +1007,7 @@ msgid ""
 "Both %1 and QR code are located inside of Preferences page of %2 you're "
 "going to connect to."
 msgstr ""
-"І %1, і QR-код знаходяться на сторінці Вподобань %2 до якої ви збираєтесь "
+"%1 і QR-код знаходяться на сторінці Налаштувань %2, до якої ви збираєтесь "
 "підключитися."
 
 msgctxt "ConnectToRemoteAppDialog|"
@@ -2621,7 +2621,7 @@ msgstr "Додатки..."
 
 msgctxt "MainMenu|"
 msgid "Preferences..."
-msgstr "Вподобання..."
+msgstr "Налаштування..."
 
 msgctxt "MainMenu|"
 msgid "Contact support"
@@ -2972,7 +2972,7 @@ msgstr "Перевірити оновлення..."
 
 msgctxt "NativeMenuBar|"
 msgid "Preferences..."
-msgstr "Вподобання..."
+msgstr "Налаштування..."
 
 msgctxt "NativeMenuBar|"
 msgid "Quit"
@@ -4436,7 +4436,7 @@ msgstr ". Все одно закрити?"
 
 msgctxt "SettingsPage|"
 msgid "Preferences"
-msgstr "Вподобання"
+msgstr "Налаштування"
 
 msgctxt "SettingsPage|"
 msgid "General"


### PR DESCRIPTION
Since I'm [@bohdangnatiuk](https://github.com/bohdangnatiuk) most likely blocked, as I can no longer submit duplicate Pull requests, and after deleting the repository, I can't even fork it again, I am duplicating my message from a friend's page, who, by the way, also considers it a translation problem.

What's low quality?🤦‍♂️ These're corrections to an existing translation. And the main reason for making them is that the translation of one of the main menu items in Ukrainian, if not the main one at all, is absolutely incorrect. Item: "Налаштування" (in English it's "Preferences", i.e. a synonym of the word "Settings") is translated as: "Вподобання" (the most appropriate English equivalent: "Likes"). This, most likely, is connected with the machine translation, and the person who translated either didn't notice this, or simply doesn't know Ukrainian very well. Would it be acceptable to you if in English instead of "Preferences" you had "Likes" as a menu item? Would it satisfy you, and would you even guess that under the "Likes" item there are actually "Preferences"?! Although the word "Preferences" has several meanings, but in this case, it's the point that is responsible for "Settings", so in Ukrainian it should be "Налаштування", accordingly, that's why in the Russian translation we see the translation of this word as "Настройки", not as "Предпочтения". I've been using FDM for more than one year and at first, I couldn't find the "Preferences" item at all because it's hard to guess that it's called "Likes", only by trial and error. I hoped that the author of the translation himself would fix this over time, but it didn't happen. And since my acquaintances also use FDM based on my recommendations, and I got tired of explaining to them every time that "Likes" are actually "Preferences", so I decided to see if it is possible to make changes to the translation myself. That's all. All other changes are those inaccuracies related to the translation of the word "Preferences", which I noticed during his search for use in the text. And since I noticed, I decided to fix it. Since I also speak Russian, I decided to see if everything is ok in the Russian translation at this moment. Therefore, writing the word "Настроек" instead of "настроек", that is, simply with a capital letter, is just standardization in accordance with other languages. We can continue to elaborate on each of my actions, but I don't see any point in this. Of course, there are probably other inaccuracies in the translation, but I fixed the gross problem that bothered me. If someone else sees other inaccuracies and wants to correct them, that's great. As for me, this is how it works, and the community translation should work. I think everything is clear. Below, I'll attach a screenshot so you can see that the word "Preferences" in Ukrainian indeed has several meanings and in this case, it's translated absolutely incorrectly. And this is really a problem when the main menu item that is used by almost everyone cannot be found because it's not translated correctly.

I'm resending Pull requests, hoping for your understanding and that, on the second attempt, you'll be able to accept these corrections.

![111](https://github.com/FreeDownloadManagerTeam/FDM6-localization/assets/139626195/b71f26b1-53f2-460f-801b-aea4e1c95d62)
