### PR TITLE
Correction for Ukrainian language (Update fdm_uk.po)

### DIFF
--- a/main/fdm_uk.po
+++ b/main/fdm_uk.po
@@ -2560,7 +2560,7 @@ msgstr "Про програму"
 
 msgctxt "LeftDrawer|"
 msgid "Quit"
-msgstr "Вихід"
+msgstr "Вийти"
 
 msgctxt "LeftDrawer|"
 msgid "Add new download"
@@ -2712,7 +2712,7 @@ msgstr "Про програму"
 
 msgctxt "MainMenu|"
 msgid "Quit"
-msgstr "Вихід"
+msgstr "Вийти"
 
 msgctxt "MainStatusBar|"
 msgid "Snail mode frees bandwidth without stopping downloads."
@@ -3031,7 +3031,7 @@ msgstr "Налаштування..."
 
 msgctxt "NativeMenuBar|"
 msgid "Quit"
-msgstr "Вихід"
+msgstr "Вийти"
 
 msgctxt "NativeMenuBar|"
 msgid "&File"
@@ -3233,7 +3233,7 @@ msgstr "Надати дозволи"
 
 msgctxt "OsPermissionsDialog|"
 msgid "Quit"
-msgstr "Вихід"
+msgstr "Вийти"
 
 msgctxt "OsPermissionsDialog|"
 msgid "Close"
@@ -3563,7 +3563,7 @@ msgstr "Технічна підтримка"
 
 msgctxt "QObject|"
 msgid "Exit"
-msgstr "Вихід"
+msgstr "Вийти"
 
 msgctxt "QObject|"
 msgid "Show main window"
@@ -3575,7 +3575,7 @@ msgstr "Про %1"
 
 msgctxt "QObject|"
 msgid "Quit"
-msgstr "Вихід"
+msgstr "Вийти"
 
 msgctxt "QObject|"
 msgid "%1 B"


### PR DESCRIPTION
It’s more accurate to translate "Exit/Quit" not as the noun "Вихід" but as the verb "Вийти", as seen in apps from Apple or Microsoft.