### PR TITLE
Eliminado no verbo REMOVER

### DIFF
--- a/main/fdm_es.po
+++ b/main/fdm_es.po
@@ -13,7 +13,7 @@ msgstr ""
 "X-Language: es\n"
 "X-Source-Language: en\n"
 "X-Qt-Contexts: true\n"
-"X-Generator: Poedit 3.4.4\n"
+"X-Generator: Poedit 3.5\n"
 
 msgctxt "AboutDialog|"
 msgid "About"
@@ -282,7 +282,7 @@ msgstr "Acción del botón borrar"
 
 msgctxt "AdvancedSettings|"
 msgid "Remove only from download list"
-msgstr "Remover solo de la lista de descargas"
+msgstr "Eliminar solo de la lista de descargas"
 
 msgctxt "AdvancedSettings|"
 msgid "Delete files"
@@ -690,7 +690,7 @@ msgstr "Descargar medio"
 
 msgctxt "Browser MainMenu|"
 msgid "Remove bookmark"
-msgstr "Remover marcador"
+msgstr "Eliminar marcador"
 
 msgctxt "Browser MainMenu|"
 msgid "Add bookmark"
@@ -1282,7 +1282,7 @@ msgstr "Establecer sonido"
 
 msgctxt "CustomizeSoundsDialog|"
 msgid "Remove"
-msgstr "Remover"
+msgstr "Eliminar"
 
 msgctxt "CustomizeSoundsDialog|"
 msgid "Test"
@@ -1306,7 +1306,7 @@ msgstr "Borrar archivos"
 
 msgctxt "DeleteDownloadsDialog|"
 msgid "Remove from list"
-msgstr "Remover de la lista"
+msgstr "Eliminar de la lista"
 
 msgctxt "DeleteDownloadsDialog|"
 msgid "Cancel"
@@ -1585,12 +1585,13 @@ msgstr "Iniciar descarga sin confirmación"
 
 msgctxt "DownloadsSettings|"
 msgid "Automatically remove deleted files from download list"
-msgstr "Remover automáticamente los archivos borrados de la lista de descargas"
+msgstr ""
+"Eliminar automáticamente los archivos borrados de la lista de descargas"
 
 msgctxt "DownloadsSettings|"
 msgid "Automatically remove completed downloads from download list"
 msgstr ""
-"Remover automáticamente las descargas completadas de la lista de descargas"
+"Eliminar automáticamente las descargas completadas de la lista de descargas"
 
 msgctxt "DownloadsSettings|"
 msgid "Immediately"
@@ -1738,7 +1739,7 @@ msgstr "Borrar archivo"
 
 msgctxt "DownloadsViewItemContextMenu|"
 msgid "Remove from list"
-msgstr "Remover de la lista"
+msgstr "Eliminar de la lista"
 
 msgctxt "DownloadsViewItemContextMenu|"
 msgid "Play file while it is still downloading"
@@ -1818,7 +1819,7 @@ msgstr "Descarga secuencial"
 
 msgctxt "DownloadsViewItemContextMenu2|"
 msgid "Remove from list"
-msgstr "Remover de la lista"
+msgstr "Eliminar de la lista"
 
 msgctxt "DownloadsViewItemContextMenu2|"
 msgid "Restart"
@@ -2325,12 +2326,13 @@ msgstr "Habilitar ventanas de descargas independientes"
 
 msgctxt "GeneralSettings|"
 msgid "Automatically remove deleted files from download list"
-msgstr "Remover automáticamente los archivos borrados de la lista de descargas"
+msgstr ""
+"Eliminar automáticamente los archivos borrados de la lista de descargas"
 
 msgctxt "GeneralSettings|"
 msgid "Automatically remove completed downloads from download list"
 msgstr ""
-"Remover automáticamente las descargas completadas de la lista de descargas"
+"Eliminar automáticamente las descargas completadas de la lista de descargas"
 
 msgctxt "GeneralSettings|"
 msgid "Immediately"
@@ -3094,7 +3096,7 @@ msgstr "Reiniciar seleccionada"
 
 msgctxt "NativeMenuBar|"
 msgid "Remove from List"
-msgstr "Remover de la lista"
+msgstr "Eliminar de la lista"
 
 msgctxt "NativeMenuBar|"
 msgid "Help"
@@ -3463,7 +3465,7 @@ msgstr "Comprobar actualizaciones"
 
 msgctxt "PluginsViewItem|"
 msgid "Remove"
-msgstr "Remover"
+msgstr "Eliminar"
 
 msgctxt "PluginsViewItem|"
 msgid "Updating..."
@@ -4859,7 +4861,7 @@ msgstr "Editar"
 
 msgctxt "TagMenu|"
 msgid "Remove"
-msgstr "Remover"
+msgstr "Eliminar"
 
 msgctxt "TagPalette|"
 msgid "Customize color"


### PR DESCRIPTION
The "remover" verb in spanish doesn´t match with the english action "to remove". In Englis is like "to eliminate" but in spanish es to move the components/ingredients of something to mix all of them, so i change it to "Eliminar"